### PR TITLE
Proposes a better edge coordinate svg

### DIFF
--- a/src/lib/coordinates/EdgeCoordinate.jsx
+++ b/src/lib/coordinates/EdgeCoordinate.jsx
@@ -136,8 +136,26 @@ EdgeCoordinate.drawOnCanvasStatic = (ctx, props) => {
 	if (isDefined(edge.coordinateBase)) {
 		ctx.fillStyle = hexToRGBA(edge.coordinateBase.fill, edge.coordinateBase.opacity);
 
+    var x = edge.coordinateBase.edgeXRect;
+    var y = edge.coordinateBase.edgeYRect;
+
 		ctx.beginPath();
-		ctx.rect(edge.coordinateBase.edgeXRect, edge.coordinateBase.edgeYRect, edge.coordinateBase.rectWidth, edge.coordinateBase.rectHeight);
+
+    if (edge.orient === 'right') {
+      ctx.lineTo(x, y + 10);
+      ctx.lineTo(x + 10, y);
+      ctx.lineTo(x + 60, y);
+      ctx.lineTo(x + 60, y + 20);
+      ctx.lineTo(x + 10, y + 20);
+    } else if (edge.orient === 'left') {
+      ctx.lineTo(x, y);
+      ctx.lineTo(x + 50, y);
+      ctx.lineTo(x + 60, y + 10);
+      ctx.lineTo(x + 50, y + 20);
+      ctx.lineTo(x, y + 20);
+    } else {
+      ctx.rect(x, y, edge.coordinateBase.rectWidth, edge.coordinateBase.rectHeight);
+    }
 		ctx.fill();
 
 		ctx.font = `${ edge.coordinate.fontSize }px ${edge.coordinate.fontFamily}`;

--- a/src/lib/coordinates/EdgeCoordinate.jsx
+++ b/src/lib/coordinates/EdgeCoordinate.jsx
@@ -141,21 +141,21 @@ EdgeCoordinate.drawOnCanvasStatic = (ctx, props) => {
 
 		ctx.beginPath();
 
-    if (edge.orient === 'right') {
-      ctx.lineTo(x, y + 10);
-      ctx.lineTo(x + 10, y);
-      ctx.lineTo(x + 60, y);
-      ctx.lineTo(x + 60, y + 20);
-      ctx.lineTo(x + 10, y + 20);
-    } else if (edge.orient === 'left') {
-      ctx.lineTo(x, y);
-      ctx.lineTo(x + 50, y);
-      ctx.lineTo(x + 60, y + 10);
-      ctx.lineTo(x + 50, y + 20);
-      ctx.lineTo(x, y + 20);
-    } else {
-      ctx.rect(x, y, edge.coordinateBase.rectWidth, edge.coordinateBase.rectHeight);
-    }
+		if (edge.orient === 'right') {
+			ctx.lineTo(x, y + 10);
+			ctx.lineTo(x + 10, y);
+			ctx.lineTo(x + 60, y);
+			ctx.lineTo(x + 60, y + 20);
+			ctx.lineTo(x + 10, y + 20);
+		} else if (edge.orient === 'left') {
+			ctx.lineTo(x, y);
+			ctx.lineTo(x + 50, y);
+			ctx.lineTo(x + 60, y + 10);
+			ctx.lineTo(x + 50, y + 20);
+			ctx.lineTo(x, y + 20);
+		} else {
+			ctx.rect(x, y, edge.coordinateBase.rectWidth, edge.coordinateBase.rectHeight);
+		}
 		ctx.fill();
 
 		ctx.font = `${ edge.coordinate.fontSize }px ${edge.coordinate.fontFamily}`;

--- a/src/lib/coordinates/EdgeCoordinate.jsx
+++ b/src/lib/coordinates/EdgeCoordinate.jsx
@@ -20,11 +20,21 @@ class EdgeCoordinate extends Component {
 				x2={edge.line.x2} y2={edge.line.y2} />;
 		}
 		if (isDefined(edge.coordinateBase)) {
-			coordinateBase = <rect key={1} className="react-stockchart-text-background"
-				x={edge.coordinateBase.edgeXRect}
-				y={edge.coordinateBase.edgeYRect}
-				height={edge.coordinateBase.rectHeight} width={edge.coordinateBase.rectWidth}
-				fill={edge.coordinateBase.fill}  opacity={edge.coordinateBase.opacity} />;
+			var path = edge.orient === "left"
+				? "M0,0L0,20L50,20L60,10L50,0L0,0L0,0"
+				: "M0,10L10,20L60,20L60,0L10,0L0,10";
+
+				coordinateBase = edge.orient === "left" || edge.orient === "right"
+				? <g transform={`translate(${edge.coordinateBase.edgeXRect},${edge.coordinateBase.edgeYRect})`}>
+						<path d={path} key={1} className="react-stockchart-text-background"
+							height={edge.coordinateBase.rectHeight} width={edge.coordinateBase.rectWidth}
+							fill={edge.coordinateBase.fill} opacity={edge.coordinateBase.opacity} />
+					</g>
+				: <rect key={1} className="react-stockchart-text-background"
+						x={edge.coordinateBase.edgeXRect}
+						y={edge.coordinateBase.edgeYRect}
+						height={edge.coordinateBase.rectHeight} width={edge.coordinateBase.rectWidth}
+						fill={edge.coordinateBase.fill} opacity={edge.coordinateBase.opacity} />;
 
 			coordinate = (<text key={2} x={edge.coordinate.edgeXText}
 				y={edge.coordinate.edgeYText}
@@ -112,7 +122,7 @@ EdgeCoordinate.helper = (props) => {
 		opacity: lineOpacity, stroke: lineStroke, x1, y1, x2, y2
 	};
 	return {
-		coordinateBase, coordinate, line
+		coordinateBase, coordinate, line, orient
 	};
 };
 


### PR DESCRIPTION
Hi, thanks for the library, it's really AWESOME and has helped me a lot.

I was trying to change the things a little bit on the edge coordinate SVG rect, so this is the result. 

before:
![screen shot 2016-05-20 at 06 17 20](https://cloud.githubusercontent.com/assets/5366959/15425642/f6f4019e-1e5f-11e6-9109-b0f983402cf8.png)

after:
![screen shot 2016-05-20 at 06 17 00](https://cloud.githubusercontent.com/assets/5366959/15425646/016366ec-1e60-11e6-908b-f70112ef4203.png)

I know, it's not that useful at all, sorry about that, i was trying to do it on my personal project, but i decided to pull this request anyway (please, feel free to reject it). But it's basically replaces the `rect` by a `path` with a couple points that indicates a little arrow, only for `left` and `right` edges, `top` and `bottom` remains the same rect, i'm also wondering whether it should be a option to choose render as rect or a path, but it also can be unnecessary.

All examples are working fine with svg, but canvas + svg doesn't, and i'm not sure why, it still shows me the old rect, i think i missing something, i don't know...

Thanks in advance.
