### PR TITLE
add className `react-stockcharts-tooltip-content` on `HoverTooltip`

### DIFF
--- a/src/lib/tooltip/HoverTooltip.jsx
+++ b/src/lib/tooltip/HoverTooltip.jsx
@@ -53,7 +53,7 @@ class HoverTooltip extends Component {
 		return (
 			<g>
 				<rect x={centerX - drawWidth / 2} y={0} width={drawWidth} height={height} fill={bgFill} opacity={bgOpacity} />
-				<g transform={`translate(${x}, ${y})`}>
+				<g className="react-stockcharts-tooltip-content" transform={`translate(${x}, ${y})`}>
 					{backgroundShapeSVG(this.props)}
 					{tooltipSVG(this.props, content)}
 				</g>


### PR DESCRIPTION
So that, the tooltip content can get styling from css.

Many thanks.