### PR TITLE
Add strokeWidth prop to Area and Line Series

### DIFF
--- a/src/lib/series/AreaSeries.jsx
+++ b/src/lib/series/AreaSeries.jsx
@@ -10,7 +10,7 @@ import wrap from "./wrap";
 class AreaSeries extends Component {
 	render() {
 		var { props } = this;
-		var { className, xScale, yScale, xAccessor, yAccessor, plotData, type, stroke, fill, baseAt } = props;
+		var { className, xScale, yScale, xAccessor, yAccessor, plotData, type, stroke, strokeWidth, fill, baseAt } = props;
 
 		var { opacity } = props;
 
@@ -21,6 +21,7 @@ class AreaSeries extends Component {
 					xAccessor={xAccessor} yAccessor={yAccessor}
 					plotData={plotData}
 					stroke={stroke} fill="none"
+					strokeWidth={strokeWidth}
 					type={type} />
 				<Area
 					xScale={xScale} yScale={yScale}
@@ -36,6 +37,7 @@ class AreaSeries extends Component {
 
 AreaSeries.propTypes = {
 	stroke: PropTypes.string,
+	strokeWidth: PropTypes.number,
 	fill: PropTypes.string.isRequired,
 	opacity: PropTypes.number.isRequired,
 	className: PropTypes.string,
@@ -43,6 +45,7 @@ AreaSeries.propTypes = {
 
 AreaSeries.defaultProps = {
 	stroke: "#4682B4",
+	strokeWidth: 1,
 	opacity: 0.5,
 	fill: "#4682B4",
 	className: "react-stockcharts-area"

--- a/src/lib/series/Line.jsx
+++ b/src/lib/series/Line.jsx
@@ -9,10 +9,10 @@ import { first } from "../utils";
 
 class Line extends Component {
 	render() {
-		var { stroke, fill, className } = this.props;
+		var { stroke, strokeWidth, fill, className } = this.props;
 
 		className = className.concat((stroke) ? "" : " line-stroke");
-		return <path d={Line.getPath(this.props)} stroke={stroke} fill={fill} className={className}/>;
+		return <path d={Line.getPath(this.props)} stroke={stroke} strokeWidth={strokeWidth} fill={fill} className={className}/>;
 	}
 }
 
@@ -24,6 +24,7 @@ Line.propTypes = {
 	yAccessor: PropTypes.func.isRequired,
 	plotData: PropTypes.array.isRequired,
 	stroke: PropTypes.string,
+	strokeWidth: PropTypes.number,
 	fill: PropTypes.string,
 };
 
@@ -31,6 +32,7 @@ Line.defaultProps = {
 	className: "line ",
 	fill: "none",
 	stroke: "black",
+	strokeWidth: 1,
 	defined: d => !isNaN(d),
 };
 
@@ -58,8 +60,9 @@ function segment(points, ctx) {
 }
 
 Line.drawOnCanvas = (props, ctx, xScale, yScale, plotData) => {
-	var { xAccessor, yAccessor, stroke, defined } = props;
+	var { xAccessor, yAccessor, stroke, strokeWidth, defined } = props;
 
+	ctx.lineWidth = strokeWidth;
 	ctx.strokeStyle = stroke;
 
 	var points = [];

--- a/src/lib/series/LineSeries.jsx
+++ b/src/lib/series/LineSeries.jsx
@@ -8,7 +8,7 @@ import wrap from "./wrap";
 class LineSeries extends Component {
 	render() {
 		var { props } = this;
-		let { className, xScale, yScale, xAccessor, yAccessor, plotData, stroke, type } = props;
+		let { className, xScale, yScale, xAccessor, yAccessor, plotData, stroke, strokeWidth, type } = props;
 		return (
 			<Line
 				className={className}
@@ -16,6 +16,7 @@ class LineSeries extends Component {
 				xAccessor={xAccessor} yAccessor={yAccessor}
 				plotData={plotData}
 				stroke={stroke} fill="none"
+				strokeWidth={strokeWidth}
 				type={type} />
 		);
 	}
@@ -23,11 +24,13 @@ class LineSeries extends Component {
 
 LineSeries.propTypes = {
 	className: PropTypes.string,
+	strokeWidth: PropTypes.number,
 };
 
 LineSeries.defaultProps = {
 	stroke: "#4682B4",
-	className: "line "
+	className: "line ",
+	strokeWidth: 1,
 };
 
 LineSeries.yAccessor = (d) => d.close;


### PR DESCRIPTION
I would to increase the stroke width on AreaSeries and LineSeries, increase too much can be very unnecessary and ugly, but i think thinner strokes can also benefit of it.
