### PR TITLE
deleted redundant export default in lib/interactive/makeInteractive.jsx

### DIFF
--- a/src/lib/interactive/makeInteractive.jsx
+++ b/src/lib/interactive/makeInteractive.jsx
@@ -201,4 +201,3 @@ export default function makeInteractive(InteractiveComponent, initialState) {
 		displayXAccessor: PropTypes.func.isRequired,
 	});
 }
-export default makeInteractive;


### PR DESCRIPTION
There's a redundant export default.