### PR TITLE
Fix multiple default exports

### DIFF
--- a/src/lib/interactive/makeInteractive.jsx
+++ b/src/lib/interactive/makeInteractive.jsx
@@ -201,4 +201,3 @@ export default function makeInteractive(InteractiveComponent, initialState) {
 		displayXAccessor: PropTypes.func.isRequired,
 	});
 }
-export default makeInteractive;


### PR DESCRIPTION
File makeInteractive.jsx has two 'export default' statements,
causing webpack to throw a syntax error when bundling