### PR TITLE
Fix #143: Export ToolTip helper components

### DIFF
--- a/src/lib/tooltip/index.js
+++ b/src/lib/tooltip/index.js
@@ -7,6 +7,8 @@ import BollingerBandTooltip from "./BollingerBandTooltip";
 import RSITooltip from "./RSITooltip";
 import StochasticTooltip from "./StochasticTooltip";
 import HoverTooltip from "./HoverTooltip";
+import ToolTipText from "./ToolTipText";
+import ToolTipTSpanLabel from "./ToolTipTSpanLabel";
 
 export {
 	MACDTooltip,
@@ -17,5 +19,7 @@ export {
 	BollingerBandTooltip,
 	RSITooltip,
 	StochasticTooltip,
-	HoverTooltip
+	HoverTooltip,
+	ToolTipText,
+	ToolTipTSpanLabel
 };


### PR DESCRIPTION
ToolTipText and ToolTipTSpanLabel are useful when making custom
tooltips, so they should be made available as imports in the lib