### PR TITLE
HoverTooltip followed by a yAccessor

### DIFF
--- a/docs/lib/charts/CandleStickChartWithHoverTooltip.jsx
+++ b/docs/lib/charts/CandleStickChartWithHoverTooltip.jsx
@@ -97,7 +97,7 @@ class CandleStickChartWithHoverTooltip extends React.Component {
 
 					<BarSeries yAccessor={d => d.volume} fill={d => d.close > d.open ? "#6BA583" : "#FF0000"} />
 				</Chart>
-				<HoverTooltip tooltipContent={tooltipContent([ema20, ema50])} bgwidth={120} bgheight={95} />
+        <HoverTooltip chartId={1} yAccessor={ema50.accessor()} tooltipContent={tooltipContent([ema20, ema50])} bgwidth={120} bgheight={95} />
 			</ChartCanvas>
 		);
 	}

--- a/src/lib/tooltip/HoverTooltip.jsx
+++ b/src/lib/tooltip/HoverTooltip.jsx
@@ -16,7 +16,7 @@ class HoverTooltip extends Component {
 		var { height } = moreProps;
 
 		if (isNotDefined(pointer)) return null;
-		drawOnCanvas(ctx, this.props, this.context, pointer, height);
+		drawOnCanvas(ctx, this.props, this.context, pointer, height, moreProps);
 	}
 	render() {
 		return <GenericComponent
@@ -32,10 +32,22 @@ class HoverTooltip extends Component {
 
 		if (isNotDefined(pointer)) return null;
 
-		var { bgFill, bgOpacity, backgroundShapeSVG } = this.props;
-		var { height } = moreProps;
+		var { chartId, yAccessor, bgFill, bgOpacity, bgwidth, bgheight, backgroundShapeSVG } = this.props;
+		var { height, xAccessor, xScale, chartConfig, currentItem } = moreProps;
 
 		var { x, y, content, centerX, drawWidth } = pointer;
+
+		if (chartId && yAccessor) {
+			var xValue = xAccessor(currentItem);
+			var yValue = yAccessor(currentItem);
+			var chartIndex = chartConfig.findIndex(x => x.id === chartId)
+
+			x = Math.round(xScale(xValue));
+			y = Math.round(chartConfig[chartIndex].yScale(yValue));
+
+			x = (x - bgwidth  - PADDING * 2 < 0) ? x + PADDING : x - bgwidth - PADDING;
+			y = (y - bgheight < 0) ? y + PADDING : y - bgheight - PADDING;
+		}
 
 		return (
 			<g>
@@ -50,6 +62,8 @@ class HoverTooltip extends Component {
 }
 
 HoverTooltip.propTypes = {
+	chartId: PropTypes.number,
+	yAccessor: PropTypes.func,
 	backgroundShapeSVG: PropTypes.func,
 	bgwidth: PropTypes.number.isRequired,
 	bgheight: PropTypes.number.isRequired,
@@ -153,11 +167,12 @@ function origin(mouseXY, bgheight, bgwidth, xAccessor, currentItem, xScale) {
 	return [originX, originY];
 }
 
-function drawOnCanvas(ctx, props, context, pointer, height) {
+function drawOnCanvas(ctx, props, context, pointer, height, moreProps) {
 
 	var { margin, ratio } = context;
-	var { bgFill, bgOpacity } = props;
+	var { bgwidth, bgheight, bgFill, bgOpacity, chartId, yAccessor } = props;
 	var { backgroundShapeCanvas, tooltipCanvas } = props;
+	var { xAccessor, xScale, chartConfig, currentItem } = moreProps;
 
 	var originX = 0.5 * ratio + margin.left;
 	var originY = 0.5 * ratio + margin.top;
@@ -170,6 +185,18 @@ function drawOnCanvas(ctx, props, context, pointer, height) {
 	ctx.translate(originX, originY);
 
 	var { x, y, content, centerX, drawWidth } = pointer;
+
+	if (chartId && yAccessor) {
+		var xValue = xAccessor(currentItem);
+		var yValue = yAccessor(currentItem);
+		var chartIndex = chartConfig.findIndex(x => x.id === chartId)
+
+		x = Math.round(xScale(xValue));
+		y = Math.round(chartConfig[chartIndex].yScale(yValue));
+
+		x = (x - bgwidth  - PADDING * 2 < 0) ? x + PADDING : x - bgwidth - PADDING;
+		y = (y - bgheight < 0) ? y + PADDING : y - bgheight - PADDING;
+	}
 
 	ctx.fillStyle = hexToRGBA(bgFill, bgOpacity);
 	ctx.beginPath();


### PR DESCRIPTION
This allows us to set HoverTooltip to follows a yAccessor instead of the mouse point, 2 new props were added on HoverTooltip, `chartId` and `yAccessor`, since the HoverTooltip is out of the Chart itself, i didn't had a way to get which chart to access yScale function, so i had add the `chartId` prop to refers it, and the `yAccessor` prop itself, if both props were not provided, it fallback to the mouse point default behavior, we could also add a specific property to it, i would like to hear a feedback from you.

here's some examples

Follows by mouse.

![chart-mouse](https://cloud.githubusercontent.com/assets/5366959/19416964/a114132e-937e-11e6-8a19-95de7e7bf01e.gif)

Follows by a yAccessor, e.g.: `ema50.accessor()`

![chart-yaccessor](https://cloud.githubusercontent.com/assets/5366959/19416971/bd7ab22a-937e-11e6-9842-bdc371cb7a53.gif)

Also, both svg and canvas works, and the padding limits works as well.