### PR TITLE
fix #184 and #185

### DIFF
--- a/src/lib/EventCapture.jsx
+++ b/src/lib/EventCapture.jsx
@@ -182,12 +182,15 @@ class EventCapture extends Component {
 			if (!this.panHappened) {
 				if (this.clicked) {
 					onDoubleClick(newPos, e);
+					this.clicked = false;
 				} else {
 					this.clicked = true;
 					setTimeout(() => {
-						this.clicked = false;
+						if (this.clicked) {
+							onClick(newPos, e);
+							this.clicked = false;
+						}
 					}, 300);
-					onClick(newPos, e);
 				}
 			}
 

--- a/src/lib/interactive/ClickCallback.jsx
+++ b/src/lib/interactive/ClickCallback.jsx
@@ -9,9 +9,15 @@ class ClickCallback extends Component {
 	constructor(props) {
 		super(props);
 		this.handleClick = this.handleClick.bind(this);
+		this.handleContextMenu = this.handleContextMenu.bind(this);
+		this.saveNode = this.saveNode.bind(this);
+		this.getClickProps = this.getClickProps.bind(this);
 	}
-	handleClick(e) {
-		var moreProps = this.refs.component.getMoreProps();
+	saveNode(node) {
+		this.node = node;
+	}
+	getClickProps() {
+		var moreProps = this.node.getMoreProps();
 
 		var {
 			// xScale,
@@ -27,14 +33,21 @@ class ClickCallback extends Component {
 
 		var yValue = yScale.invert(mouseXY[1]);
 		var xValue = displayXAccessor(currentItem);
-		this.props.onClick({
+
+		return {
 			xy: [xValue, yValue],
 			mouseXY,
 			currentItem
-		}, e);
+		};
+	}
+	handleContextMenu(e) {
+		this.props.onContextMenu(this.getClickProps(), e);
+	}
+	handleClick(e) {
+		this.props.onClick(this.getClickProps(), e);
 	}
 	render() {
-		return <GenericChartComponent ref="component"
+		return <GenericChartComponent ref={this.saveNode}
 			svgDraw={functor(null)}
 			isHover={functor(true)}
 			onClick={this.handleClick}
@@ -47,10 +60,12 @@ ClickCallback.drawOnCanvas = noop;
 
 ClickCallback.propTypes = {
 	onClick: PropTypes.func.isRequired,
+	onContextMenu: PropTypes.func.isRequired,
 };
 
 ClickCallback.defaultProps = {
-	onClick: (e) => { console.log(e); },
+	onClick: (...rest) => { console.log(rest); },
+	onContextMenu: (...rest) => { console.log(rest); },
 };
 
 export default ClickCallback;


### PR DESCRIPTION
#184 

Right click is expected, as that is what react gives from its synthetic event system
Fixed doubleclick so it does not fire a click

http://rrag.github.io/react-stockcharts/documentation.html#/edge_coordinate

The click is delayed by 300ms to determine if there is a doubleclick.

#185 

Added `onContextMenu` 

http://rrag.github.io/react-stockcharts/documentation.html#/click_callback