### PR TITLE
Update debug module to 2.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "d3-shape": "^1.0.3",
     "d3-time-format": "^2.0.2",
     "d3fc-rebind": "^4.1.1",
-    "debug": "^2.3.3",
+    "debug": "^2.4.1",
     "lodash.flattendeep": "^4.4.0",
     "save-svg-as-png": "^1.0.3"
   },


### PR DESCRIPTION
The debug v.2.3.3 has a syntax error, which was fixed within v.2.4.1