### PR TITLE
Allow overwrite tooltipSVG function

### DIFF
--- a/src/lib/tooltip/HoverTooltip.jsx
+++ b/src/lib/tooltip/HoverTooltip.jsx
@@ -33,7 +33,7 @@ class HoverTooltip extends Component {
 
 		if (isNotDefined(pointer)) return null;
 
-		var { bgFill, bgOpacity, backgroundShapeSVG } = this.props;
+		var { bgFill, bgOpacity, backgroundShapeSVG, tooltipSVG } = this.props;
 		var { height } = moreProps;
 
 		var { x, y, content, centerX, pointWidth, bgSize } = pointer;
@@ -58,6 +58,7 @@ class HoverTooltip extends Component {
 HoverTooltip.propTypes = {
 	chartId: PropTypes.number,
 	yAccessor: PropTypes.func,
+	tooltipSVG: PropTypes.func,
 	backgroundShapeSVG: PropTypes.func,
 	bgwidth: PropTypes.number.isRequired,
 	bgheight: PropTypes.number.isRequired,


### PR DESCRIPTION
I forgot to create this pull requests before, so sorry about that.

I was using a custom `tooltipSVG` function, and this pull request just take the function from the props, since the default `tooltipSVG` function are already defined on `defaultProps`.

Also, i just realized that 78748ed1852a8967072c8e26c2a7f7716b2361c9 breaks my custom tooltip width and height, it was setting `backgroundShapeSVG` width and height from `bgwidth` and `bgheight` props, and now it's taken from the `pointer.bgSize`, and i am not sure yet how it works, but i think we should take a look at it to support custom tooltips.
