### PR TITLE
HotFix pinch to zoom - issue #122 

### DIFF
--- a/src/lib/utils/ChartDataUtil.js
+++ b/src/lib/utils/ChartDataUtil.js
@@ -12,6 +12,7 @@ import {
 	getClosestItem,
 	zipper,
 	isDefined,
+	isArray,
 	functor,
 } from "./index";
 
@@ -133,7 +134,7 @@ export function getChartConfigWithUpdatedYScales(chartConfig, plotData, xDomain,
 		.combine((config, { realYDomain, yDomainDY, prevYDomain }) => {
 			var { id, padding, height, yScale, yPan, flipYScale, yPanEnabled = false } = config;
 
-			var another = isDefined(chartsToPan)
+			var another = (isDefined(chartsToPan) && isArray(chartsToPan))
 				? chartsToPan.indexOf(id) > -1
 				: true;
 			var domain = yPan && yPanEnabled


### PR DESCRIPTION
When testing on mobile, pinch to zoom throws error `Uncaught TypeError: chartsToPan.indexOf is not a function`.

Steps to reproduce the bug:
- Put one finger on the mobile screen
- Put a second finger on the screen and move this second finger.
- Do not move the first finger.

Because of the thrown error the render fails and the charts disappear.

This fix might not be perfect, it only prevents the render from crashing. The result behaviour might not be the one expected (zoom level reseted?).