### PR TITLE
Large performance improvement for wickNest.forEach.outer

### DIFF
--- a/docs/pageTemplate.js
+++ b/docs/pageTemplate.js
@@ -82,7 +82,7 @@ module.exports = function(params) {
 	<head>
 		<meta charset="utf-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
-		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 		<meta name="description" content="Highly customizable stock charts">
 		<meta name="author" content="rrag">
 		<!--

--- a/src/lib/series/CandlestickSeries.jsx
+++ b/src/lib/series/CandlestickSeries.jsx
@@ -146,13 +146,8 @@ function drawOnCanvas(ctx, props, moreProps) {
 		const { key, values } = outer;
 		ctx.strokeStyle = key;
 		values.forEach(d => {
-			ctx.beginPath();
-			ctx.moveTo(d.x, d.y1);
-			ctx.lineTo(d.x, d.y2);
-
-			ctx.moveTo(d.x, d.y3);
-			ctx.lineTo(d.x, d.y4);
-			ctx.stroke();
+			ctx.fillRect(d.x, d.y1, 1, d.y2 - d.y1);
+			ctx.fillRect(d.x, d.y3, 1, d.y4 - d.y3);
 		});
 	});
 

--- a/src/lib/series/CandlestickSeries.jsx
+++ b/src/lib/series/CandlestickSeries.jsx
@@ -189,11 +189,8 @@ function drawOnCanvas(ctx, props, moreProps) {
 					ctx.lineTo(d.x + d.width, d.y + d.height);
 					ctx.stroke();
 				} else {
-					ctx.beginPath();
-					ctx.rect(d.x, d.y, d.width, d.height);
-					ctx.closePath();
-					ctx.fill();
-					if (strokeKey !== "none") ctx.stroke();
+					ctx.fillRect(d.x, d.y, d.width, d.height);
+					ctx.strokeRect(d.x, d.y, d.width, d.height);
 				}
 			});
 		});


### PR DESCRIPTION
From around 5ms to 1ms on Android (Nexus 6p).

Please double check you are happy with the rendering. As I am using a different canvas method the line thickness can look slightly different.