### PR TITLE
Added a little padding on clampedDomain

### DIFF
--- a/src/lib/scale/evaluator.js
+++ b/src/lib/scale/evaluator.js
@@ -21,8 +21,8 @@ function extentsWrapper(xAccessor, useWholeData, clamp, pointsPerPxThreshold) {
 
 		const filteredData = getFilteredResponse(data, left, right, xAccessor);
 		const clampedDomain = [
-			Math.max(left, xAccessor(first(data))),
-			Math.min(right, xAccessor(last(data)))
+			Math.max(left, xAccessor(first(data)) - 1),
+			Math.min(right, xAccessor(last(data)) + 1)
 		];
 
 		const realInputDomain = xAccessor === xAccessor


### PR DESCRIPTION
This adds a little padding when using `clamp`.

Here's some screenshots.
Before (cutting the last candle):
![screen shot 2017-05-15 at 12 47 42](https://cloud.githubusercontent.com/assets/5366959/26066709/3057973c-396e-11e7-915c-6a3a6a4b5d8a.png)

After:
![screen shot 2017-05-15 at 12 48 05](https://cloud.githubusercontent.com/assets/5366959/26066716/33afd58e-396e-11e7-9b6d-b1eb3328ad5d.png)

