### PR TITLE
fix PropTypes

### DIFF
--- a/docs/lib/MenuItem.jsx
+++ b/docs/lib/MenuItem.jsx
@@ -1,5 +1,6 @@
 'use strict';
 import React from "react";
+import PropTypes from 'prop-types';
 
 class MenuItem extends React.Component {
 	render() {
@@ -15,9 +16,9 @@ class MenuItem extends React.Component {
 }
 
 MenuItem.propTypes = {
-	current: React.PropTypes.bool.isRequired,
-	title: React.PropTypes.string.isRequired,
-	anchor: React.PropTypes.string.isRequired,
+	current: PropTypes.bool.isRequired,
+	title: PropTypes.string.isRequired,
+	anchor: PropTypes.string.isRequired,
 };
 
 MenuItem.defaultProps = {

--- a/docs/lib/charts/AreaChart.jsx
+++ b/docs/lib/charts/AreaChart.jsx
@@ -1,6 +1,8 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
+
 import { scaleTime } from "d3-scale";
 
 import { ChartCanvas, Chart, series, axes, helper } from "react-stockcharts";
@@ -34,10 +36,10 @@ class AreaChart extends React.Component {
 */
 
 AreaChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 AreaChart.defaultProps = {

--- a/docs/lib/charts/AreaChartWithYPercent.jsx
+++ b/docs/lib/charts/AreaChartWithYPercent.jsx
@@ -4,6 +4,8 @@ import { scaleTime } from "d3-scale";
 import { format } from "d3-format";
 
 import React from "react";
+import PropTypes from 'prop-types';
+
 import { ChartCanvas, Chart, series, axes, helper } from "react-stockcharts";
 
 var { AreaSeries } = series;
@@ -32,10 +34,10 @@ class AreaChartWithYPercent extends React.Component {
 }
 
 AreaChartWithYPercent.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 AreaChartWithYPercent.defaultProps = {

--- a/docs/lib/charts/AreaChartWithZoomPan.jsx
+++ b/docs/lib/charts/AreaChartWithZoomPan.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -77,10 +78,10 @@ class AreaChartWithEdge extends React.Component {
 }
 
 AreaChartWithEdge.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 AreaChartWithEdge.defaultProps = {

--- a/docs/lib/charts/BarChart.jsx
+++ b/docs/lib/charts/BarChart.jsx
@@ -2,6 +2,7 @@
 
 import { scalePoint } from  "d3-scale";
 import React from "react";
+import PropTypes from 'prop-types';
 
 import { ChartCanvas, Chart, series, axes, helper } from "react-stockcharts";
 
@@ -37,10 +38,10 @@ class BarChart extends React.Component {
 }
 
 BarChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 BarChart.defaultProps = {

--- a/docs/lib/charts/BubbleChart.jsx
+++ b/docs/lib/charts/BubbleChart.jsx
@@ -6,6 +6,7 @@ import { format } from "d3-format";
 import { extent } from "d3-array";
 
 import React from "react";
+import PropTypes from 'prop-types';
 
 import { ChartCanvas, Chart, series, coordinates, axes, helper } from "react-stockcharts";
 
@@ -66,10 +67,10 @@ class BubbleChart extends React.Component {
 }
 
 BubbleChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 BubbleChart.defaultProps = {

--- a/docs/lib/charts/CandleStickChart.jsx
+++ b/docs/lib/charts/CandleStickChart.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { scaleTime } from "d3-scale";
 
 import { ChartCanvas, Chart, series, scale, coordinates, tooltip, axes, indicator, helper } from "react-stockcharts";
@@ -31,10 +32,10 @@ class CandleStickChart extends React.Component {
 }
 
 CandleStickChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChart.defaultProps = {

--- a/docs/lib/charts/CandleStickChartForContinuousIntraDay.jsx
+++ b/docs/lib/charts/CandleStickChartForContinuousIntraDay.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 
 import { scaleTime } from "d3-scale";
 import { format } from "d3-format";
@@ -120,10 +121,10 @@ class CandleStickChartForContinuousIntraDay extends React.Component {
 }
 
 CandleStickChartForContinuousIntraDay.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartForContinuousIntraDay.defaultProps = {

--- a/docs/lib/charts/CandleStickChartForDiscontinuousIntraDay.jsx
+++ b/docs/lib/charts/CandleStickChartForDiscontinuousIntraDay.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -121,10 +122,10 @@ class CandleStickChartForDiscontinuousIntraDay extends React.Component {
 }
 
 CandleStickChartForDiscontinuousIntraDay.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartForDiscontinuousIntraDay.defaultProps = {

--- a/docs/lib/charts/CandleStickChartPanToLoadMore.jsx
+++ b/docs/lib/charts/CandleStickChartPanToLoadMore.jsx
@@ -4,6 +4,7 @@ import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
 import React from "react";
+import PropTypes from 'prop-types';
 
 import { ChartCanvas, Chart, series, scale, coordinates, tooltip, axes, indicator, helper, utils } from "react-stockcharts";
 
@@ -205,17 +206,17 @@ class CandleStickChartPanToLoadMore extends React.Component {
 			</ChartCanvas>
 		);
 	}
-};
+}
 
 /*
 
 */
 
 CandleStickChartPanToLoadMore.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartPanToLoadMore.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithAnnotation.jsx
+++ b/docs/lib/charts/CandleStickChartWithAnnotation.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -116,10 +117,10 @@ class CandleStickChartWithAnnotation extends React.Component {
 */
 
 CandleStickChartWithAnnotation.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithAnnotation.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithBollingerBandOverlay.jsx
+++ b/docs/lib/charts/CandleStickChartWithBollingerBandOverlay.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -119,10 +120,10 @@ class CandleStickChartWithBollingerBandOverlay extends React.Component {
 */
 
 CandleStickChartWithBollingerBandOverlay.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithBollingerBandOverlay.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithBrush.jsx
+++ b/docs/lib/charts/CandleStickChartWithBrush.jsx
@@ -3,6 +3,7 @@
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 import React from "react";
+import PropTypes from 'prop-types';
 
 import { ChartCanvas, Chart, series, scale, coordinates, tooltip, axes, indicator, helper, interactive } from "react-stockcharts";
 
@@ -168,10 +169,10 @@ class CandlestickChart extends React.Component {
 }
 
 CandlestickChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandlestickChart.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithCHMousePointer.jsx
+++ b/docs/lib/charts/CandleStickChartWithCHMousePointer.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -59,17 +60,17 @@ class CandleStickChartWithCHMousePointer extends React.Component {
 			</ChartCanvas>
 		);
 	}
-};
+}
 
 /*
 
 
 */
 CandleStickChartWithCHMousePointer.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithCHMousePointer.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithClickHandlerCallback.jsx
+++ b/docs/lib/charts/CandleStickChartWithClickHandlerCallback.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -124,10 +125,10 @@ class CandlestickChart extends React.Component {
 }
 
 CandlestickChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandlestickChart.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithCompare.jsx
+++ b/docs/lib/charts/CandleStickChartWithCompare.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -109,10 +110,10 @@ class CandleStickChartWithCompare extends React.Component {
 };
 
 CandleStickChartWithCompare.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithCompare.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithDarkTheme.jsx
+++ b/docs/lib/charts/CandleStickChartWithDarkTheme.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -176,10 +177,10 @@ class CandleStickChartWithDarkTheme extends React.Component {
 	}
 }
 CandleStickChartWithDarkTheme.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithDarkTheme.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithEdge.jsx
+++ b/docs/lib/charts/CandleStickChartWithEdge.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -130,10 +131,10 @@ class CandleStickChartWithEdge extends React.Component {
 */
 
 CandleStickChartWithEdge.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithEdge.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithEdge_Orig.jsx
+++ b/docs/lib/charts/CandleStickChartWithEdge_Orig.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -112,12 +113,12 @@ class CandleStickChartWithEdge extends React.Component {
 						yAccessor={d => d.close} fill={d => d.close > d.open ? "#6BA583" : "#FF0000"}/>
 				</Chart>
 				<CrossHairCursor />
-				 mouseMove zoom pan />
-				<>
+				<EventCapture mouseMove zoom pan />
+				<TooltipContainer>
 					<OHLCTooltip forChart={1} origin={[-40, -65]}/>
 					<MovingAverageTooltip forChart={1} onClick={(e) => console.log(e)} origin={[-38, -55]} 
 						calculators={[ema20, ema50]}/>
-				</>
+				</TooltipContainer>
 			</ChartCanvas>
 		);
 	}
@@ -132,10 +133,10 @@ class CandleStickChartWithEdge extends React.Component {
 */
 
 CandleStickChartWithEdge.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithEdge.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithFibonacciInteractiveIndicator.jsx
+++ b/docs/lib/charts/CandleStickChartWithFibonacciInteractiveIndicator.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -168,10 +169,10 @@ class CandleStickChartWithFibonacciInteractiveIndicator extends React.Component 
 	}
 }
 CandleStickChartWithFibonacciInteractiveIndicator.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithFibonacciInteractiveIndicator.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithForceIndexIndicator.jsx
+++ b/docs/lib/charts/CandleStickChartWithForceIndexIndicator.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -125,10 +126,10 @@ class CandleStickChartWithForceIndexIndicator extends React.Component {
 };
 
 CandleStickChartWithForceIndexIndicator.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithForceIndexIndicator.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithFullStochasticsIndicator.jsx
+++ b/docs/lib/charts/CandleStickChartWithFullStochasticsIndicator.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -160,10 +161,10 @@ class CandleStickChartWithFullStochasticsIndicator extends React.Component {
 	}
 }
 CandleStickChartWithFullStochasticsIndicator.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithFullStochasticsIndicator.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithHoverTooltip.jsx
+++ b/docs/lib/charts/CandleStickChartWithHoverTooltip.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -124,10 +125,10 @@ class CandleStickChartWithHoverTooltip extends React.Component {
 }
 
 CandleStickChartWithHoverTooltip.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithHoverTooltip.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithInteractiveIndicator.jsx
+++ b/docs/lib/charts/CandleStickChartWithInteractiveIndicator.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -173,10 +174,10 @@ class CandlestickChart extends React.Component {
 }
 
 CandlestickChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandlestickChart.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithMA.jsx
+++ b/docs/lib/charts/CandleStickChartWithMA.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -121,10 +122,10 @@ class CandleStickChartWithMA extends React.Component {
 }
 
 CandleStickChartWithMA.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithMA.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithMACDIndicator.jsx
+++ b/docs/lib/charts/CandleStickChartWithMACDIndicator.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -115,13 +116,13 @@ class CandleStickChartWithMACDIndicator extends React.Component {
 			</ChartCanvas>
 		);
 	}
-};
+}
 
 CandleStickChartWithMACDIndicator.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithMACDIndicator.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithMouseFollowingTooltip.jsx
+++ b/docs/lib/charts/CandleStickChartWithMouseFollowingTooltip.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 
 import { ChartCanvas, Chart, series, scale, coordinates, tooltip, axes, indicator, helper } from "react-stockcharts";
@@ -92,10 +93,10 @@ class CandleStickChartWithMouseFollowingTooltip extends React.Component {
 */
 
 CandleStickChartWithMouseFollowingTooltip.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithMouseFollowingTooltip.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithRSIIndicator.jsx
+++ b/docs/lib/charts/CandleStickChartWithRSIIndicator.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -138,14 +139,14 @@ class CandleStickChartWithRSIIndicator extends React.Component {
 			</ChartCanvas>
 		);
 	}
-};
+}
 
 
 CandleStickChartWithRSIIndicator.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithRSIIndicator.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithSAR.jsx
+++ b/docs/lib/charts/CandleStickChartWithSAR.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -86,10 +87,10 @@ class CandleStickChartWithSAR extends React.Component {
 */
 
 CandleStickChartWithSAR.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithSAR.defaultProps = {

--- a/docs/lib/charts/CandleStickChartWithZoomPan.jsx
+++ b/docs/lib/charts/CandleStickChartWithZoomPan.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -82,10 +83,10 @@ class CandleStickChartWithZoomPan extends React.Component {
 }
 
 CandleStickChartWithZoomPan.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickChartWithZoomPan.defaultProps = {

--- a/docs/lib/charts/CandleStickStockScaleChart.jsx
+++ b/docs/lib/charts/CandleStickStockScaleChart.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from "react";
+import PropTypes from 'prop-types';
 
 import { ChartCanvas, Chart, series, scale, coordinates, tooltip, axes, indicator, helper } from "react-stockcharts";
 
@@ -35,10 +36,10 @@ class CandleStickStockScaleChart extends React.Component {
 }
 
 CandleStickStockScaleChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickStockScaleChart.defaultProps = {

--- a/docs/lib/charts/CandleStickStockScaleChartWithVolumeBarV1.jsx
+++ b/docs/lib/charts/CandleStickStockScaleChartWithVolumeBarV1.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 
 import { ChartCanvas, Chart, series, scale, coordinates, tooltip, axes, indicator, helper } from "react-stockcharts";
@@ -40,10 +41,10 @@ class CandleStickStockScaleChartWithVolumeBarV1 extends React.Component {
 }
 
 CandleStickStockScaleChartWithVolumeBarV1.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickStockScaleChartWithVolumeBarV1.defaultProps = {

--- a/docs/lib/charts/CandleStickStockScaleChartWithVolumeBarV2.jsx
+++ b/docs/lib/charts/CandleStickStockScaleChartWithVolumeBarV2.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 
 import { ChartCanvas, Chart, series, scale, coordinates, tooltip, axes, indicator, helper } from "react-stockcharts";
@@ -38,10 +39,10 @@ class CandleStickStockScaleChartWithVolumeBarV2 extends React.Component {
 }
 
 CandleStickStockScaleChartWithVolumeBarV2.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickStockScaleChartWithVolumeBarV2.defaultProps = {

--- a/docs/lib/charts/CandleStickStockScaleChartWithVolumeBarV3.jsx
+++ b/docs/lib/charts/CandleStickStockScaleChartWithVolumeBarV3.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 
 import { ChartCanvas, Chart, series, scale, coordinates, tooltip, axes, indicator, helper } from "react-stockcharts";
@@ -39,10 +40,10 @@ class CandleStickStockScaleChartWithVolumeBarV3 extends React.Component {
 	}
 }
 CandleStickStockScaleChartWithVolumeBarV3.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 CandleStickStockScaleChartWithVolumeBarV3.defaultProps = {

--- a/docs/lib/charts/GroupedBarChart.jsx
+++ b/docs/lib/charts/GroupedBarChart.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { scaleOrdinal, schemeCategory10, scalePoint } from  "d3-scale";
 import { set } from "d3-collection";
 
@@ -41,10 +42,10 @@ class GroupedBarChart extends React.Component {
 }
 
 GroupedBarChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 GroupedBarChart.defaultProps = {

--- a/docs/lib/charts/HeikinAshi.jsx
+++ b/docs/lib/charts/HeikinAshi.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -119,10 +120,10 @@ class HeikinAshi extends React.Component {
 }
 
 HeikinAshi.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 HeikinAshi.defaultProps = {

--- a/docs/lib/charts/HorizontalBarChart.jsx
+++ b/docs/lib/charts/HorizontalBarChart.jsx
@@ -4,6 +4,7 @@ import { max } from "d3-array";
 import { scaleLinear, scalePoint } from  "d3-scale";
 
 import React from "react";
+import PropTypes from 'prop-types';
 
 import { ChartCanvas, Chart, series, axes, helper } from "react-stockcharts";
 
@@ -38,10 +39,10 @@ class HorizontalBarChart extends React.Component {
 }
 
 HorizontalBarChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 HorizontalBarChart.defaultProps = {

--- a/docs/lib/charts/HorizontalStackedBarChart.jsx
+++ b/docs/lib/charts/HorizontalStackedBarChart.jsx
@@ -5,6 +5,7 @@ import { set } from "d3-collection";
 import { max } from "d3-array";
 
 import React from "react";
+import PropTypes from 'prop-types';
 
 import { ChartCanvas, Chart, series, scale, coordinates, tooltip, axes, indicator, helper } from "react-stockcharts";
 
@@ -46,10 +47,10 @@ class HorizontalStackedBarChart extends React.Component {
 }
 
 HorizontalStackedBarChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 HorizontalStackedBarChart.defaultProps = {

--- a/docs/lib/charts/Kagi.jsx
+++ b/docs/lib/charts/Kagi.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -72,10 +73,10 @@ class Kagi extends React.Component {
 }
 
 Kagi.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 Kagi.defaultProps = {

--- a/docs/lib/charts/LineAndScatterChart.jsx
+++ b/docs/lib/charts/LineAndScatterChart.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -79,10 +80,10 @@ class LineAndScatterChart extends React.Component {
 }
 
 LineAndScatterChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 LineAndScatterChart.defaultProps = {

--- a/docs/lib/charts/LineAndScatterChartGrid.jsx
+++ b/docs/lib/charts/LineAndScatterChartGrid.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -78,10 +79,10 @@ class LineAndScatterChartGrid extends React.Component {
 }
 
 LineAndScatterChartGrid.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 LineAndScatterChartGrid.defaultProps = {

--- a/docs/lib/charts/MovingAverageCrossOverAlgorithmV1.jsx
+++ b/docs/lib/charts/MovingAverageCrossOverAlgorithmV1.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -129,10 +130,10 @@ class MovingAverageCrossOverAlgorithmV1 extends React.Component {
 }
 
 MovingAverageCrossOverAlgorithmV1.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 MovingAverageCrossOverAlgorithmV1.defaultProps = {

--- a/docs/lib/charts/MovingAverageCrossOverAlgorithmV2.jsx
+++ b/docs/lib/charts/MovingAverageCrossOverAlgorithmV2.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -131,10 +132,10 @@ class MovingAverageCrossOverAlgorithmV2 extends React.Component {
 */
 
 MovingAverageCrossOverAlgorithmV2.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 MovingAverageCrossOverAlgorithmV2.defaultProps = {

--- a/docs/lib/charts/OHLCChartWithElderImpulseIndicator.jsx
+++ b/docs/lib/charts/OHLCChartWithElderImpulseIndicator.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -108,12 +109,13 @@ class OHLCChartWithElderImpulseIndicator extends React.Component {
 			</ChartCanvas>
 		);
 	}
-};
+}
+
 OHLCChartWithElderImpulseIndicator.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 OHLCChartWithElderImpulseIndicator.defaultProps = {

--- a/docs/lib/charts/OHLCChartWithElderRayIndicator.jsx
+++ b/docs/lib/charts/OHLCChartWithElderRayIndicator.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -136,13 +137,13 @@ class OHLCChartWithElderRayIndicator extends React.Component {
 			</ChartCanvas>
 		);
 	}
-};
+}
 
 OHLCChartWithElderRayIndicator.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 OHLCChartWithElderRayIndicator.defaultProps = {

--- a/docs/lib/charts/PointAndFigure.jsx
+++ b/docs/lib/charts/PointAndFigure.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -70,10 +71,10 @@ class PointAndFigure extends React.Component {
 	}
 }
 PointAndFigure.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 PointAndFigure.defaultProps = {

--- a/docs/lib/charts/Renko.jsx
+++ b/docs/lib/charts/Renko.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -67,10 +68,10 @@ class Renko extends React.Component {
 }
 
 Renko.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 Renko.defaultProps = {

--- a/docs/lib/charts/StackedBarChart.jsx
+++ b/docs/lib/charts/StackedBarChart.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 
 import { set } from "d3-collection";
 import { scaleOrdinal, schemeCategory10, scalePoint } from  "d3-scale";
@@ -41,10 +42,10 @@ class StackedBarChart extends React.Component {
 }
 
 StackedBarChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 StackedBarChart.defaultProps = {

--- a/docs/lib/charts/VolumeProfileBySessionChart.jsx
+++ b/docs/lib/charts/VolumeProfileBySessionChart.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -93,10 +94,10 @@ class VolumeProfileBySessionChart extends React.Component {
 }
 
 VolumeProfileBySessionChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 VolumeProfileBySessionChart.defaultProps = {

--- a/docs/lib/charts/VolumeProfileChart.jsx
+++ b/docs/lib/charts/VolumeProfileChart.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
 import React from "react";
+import PropTypes from 'prop-types';
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 
@@ -91,10 +92,10 @@ class VolumeProfileChart extends React.Component {
 }
 
 VolumeProfileChart.propTypes = {
-	data: React.PropTypes.array.isRequired,
-	width: React.PropTypes.number.isRequired,
-	ratio: React.PropTypes.number.isRequired,
-	type: React.PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	data: PropTypes.array.isRequired,
+	width: PropTypes.number.isRequired,
+	ratio: PropTypes.number.isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
 };
 
 VolumeProfileChart.defaultProps = {

--- a/docs/lib/content-section.jsx
+++ b/docs/lib/content-section.jsx
@@ -1,6 +1,7 @@
 'use strict';
 
 import React from "react";
+import PropTypes from 'prop-types';
 
 class ContentSection extends React.Component {
 	render() {
@@ -15,7 +16,7 @@ class ContentSection extends React.Component {
 };
 
 ContentSection.propTypes = {
-	title: React.PropTypes.string.isRequired
+	title: PropTypes.string.isRequired
 };
 
 export default ContentSection;

--- a/docs/lib/row.jsx
+++ b/docs/lib/row.jsx
@@ -1,5 +1,6 @@
 'use strict';
 import React from "react";
+import PropTypes from 'prop-types';
 
 class Row extends React.Component {
 	render() {
@@ -18,8 +19,8 @@ class Row extends React.Component {
 }
 
 Row.propTypes = {
-	title: React.PropTypes.string,
-	anchor: React.PropTypes.string
+	title: PropTypes.string,
+	anchor: PropTypes.string
 };
 
 export default Row;

--- a/docs/lib/section.jsx
+++ b/docs/lib/section.jsx
@@ -1,5 +1,6 @@
 'use strict';
 import React from "react";
+import PropTypes from 'prop-types';
 
 class Section extends React.Component {
 	render() {
@@ -15,8 +16,8 @@ class Section extends React.Component {
 }
 
 Section.propTypes = {
-	colSpan: React.PropTypes.number.isRequired,
-	title: React.PropTypes.string
+	colSpan: PropTypes.number.isRequired,
+	title: PropTypes.string
 };
 
 Section.defaultProps = {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "d3fc-rebind": "^4.1.1",
     "debug": "^2.6.0",
     "lodash.flattendeep": "^4.4.0",
+    "prop-types": "^15.5.10",
     "save-svg-as-png": "^1.0.3"
   },
   "peerDependencies": {

--- a/src/lib/BackgroundText.jsx
+++ b/src/lib/BackgroundText.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import PureComponent from "./utils/PureComponent";
 
 import { hexToRGBA, isDefined } from "./utils";

--- a/src/lib/CanvasContainer.jsx
+++ b/src/lib/CanvasContainer.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { isDefined, getLogger } from "./utils";
 
 const log = getLogger("CanvasContainer");

--- a/src/lib/Chart.jsx
+++ b/src/lib/Chart.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { scaleLinear } from "d3-scale";
 
 import PureComponent from "./utils/PureComponent";

--- a/src/lib/ChartCanvas.jsx
+++ b/src/lib/ChartCanvas.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { extent as d3Extent, min, max } from "d3-array";
 
 import {

--- a/src/lib/EventCapture.jsx
+++ b/src/lib/EventCapture.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { select, event as d3Event } from "d3-selection";
 
 import { isDefined, mousePosition, touchPosition, d3Window, MOUSEMOVE, MOUSEUP } from "./utils";

--- a/src/lib/GenericChartComponent.jsx
+++ b/src/lib/GenericChartComponent.jsx
@@ -1,6 +1,6 @@
 "use strict";
 
-import { PropTypes } from "react";
+import PropTypes from "prop-types";
 
 import GenericComponent from "./GenericComponent";
 

--- a/src/lib/GenericComponent.jsx
+++ b/src/lib/GenericComponent.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { isNotDefined, isDefined, noop, functor, identity } from "./utils";
 
 class GenericComponent extends Component {

--- a/src/lib/annotation/Annotate.jsx
+++ b/src/lib/annotation/Annotate.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import GenericChartComponent from "../GenericChartComponent";
 

--- a/src/lib/annotation/Label.jsx
+++ b/src/lib/annotation/Label.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import GenericComponent from "../GenericComponent";
 
 import { isDefined, hexToRGBA, functor } from "../utils";

--- a/src/lib/annotation/LabelAnnotation.jsx
+++ b/src/lib/annotation/LabelAnnotation.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { functor } from "../utils";
 
 class LabelAnnotation extends Component {

--- a/src/lib/annotation/SvgPathAnnotation.jsx
+++ b/src/lib/annotation/SvgPathAnnotation.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { functor } from "../utils";
 
 class SvgPathAnnotation extends Component {

--- a/src/lib/axes/Axis.jsx
+++ b/src/lib/axes/Axis.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { forceSimulation, forceX, forceCollide } from "d3-force";
 import { range as d3Range } from "d3-array";
 

--- a/src/lib/axes/AxisLine.jsx
+++ b/src/lib/axes/AxisLine.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { first, last, hexToRGBA } from "../utils";
 

--- a/src/lib/axes/AxisTicks.jsx
+++ b/src/lib/axes/AxisTicks.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { hexToRGBA, isNotDefined, identity } from "../utils";
 

--- a/src/lib/axes/AxisZoomCapture.jsx
+++ b/src/lib/axes/AxisZoomCapture.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { select, event as d3Event } from "d3-selection";
 import { mean } from "d3-array";
 

--- a/src/lib/axes/XAxis.jsx
+++ b/src/lib/axes/XAxis.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Axis from "./Axis";
 
 class XAxis extends Component {

--- a/src/lib/axes/YAxis.jsx
+++ b/src/lib/axes/YAxis.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import Axis from "./Axis";
 
 class YAxis extends Component {

--- a/src/lib/coordinates/CrossHairCursor.jsx
+++ b/src/lib/coordinates/CrossHairCursor.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import GenericComponent from "../GenericComponent";
 import PureComponent from "../utils/PureComponent";
 

--- a/src/lib/coordinates/CurrentCoordinate.jsx
+++ b/src/lib/coordinates/CurrentCoordinate.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import GenericChartComponent from "../GenericChartComponent";
 import { isNotDefined } from "../utils";

--- a/src/lib/coordinates/EdgeCoordinate.jsx
+++ b/src/lib/coordinates/EdgeCoordinate.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { hexToRGBA, isDefined } from "../utils";
 

--- a/src/lib/coordinates/EdgeIndicator.jsx
+++ b/src/lib/coordinates/EdgeIndicator.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { Component, PropTypes } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { format } from "d3-format";
 
 import { drawOnCanvas, renderSVG } from "./EdgeCoordinateV2";

--- a/src/lib/coordinates/MouseCoordinateX.jsx
+++ b/src/lib/coordinates/MouseCoordinateX.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { drawOnCanvas, renderSVG } from "./EdgeCoordinateV2";
 import GenericChartComponent from "../GenericChartComponent";

--- a/src/lib/coordinates/MouseCoordinateY.jsx
+++ b/src/lib/coordinates/MouseCoordinateY.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { drawOnCanvas, renderSVG } from "./EdgeCoordinateV2";
 import GenericChartComponent from "../GenericChartComponent";

--- a/src/lib/helper/TypeChooser.jsx
+++ b/src/lib/helper/TypeChooser.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 class TypeChooser extends Component {
 	constructor(props) {

--- a/src/lib/interactive/Brush.jsx
+++ b/src/lib/interactive/Brush.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { isDefined, noop, functor } from "../utils";
 import GenericChartComponent from "../GenericChartComponent";

--- a/src/lib/interactive/ClickCallback.jsx
+++ b/src/lib/interactive/ClickCallback.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { noop, functor } from "../utils";
 import GenericChartComponent from "../GenericChartComponent";

--- a/src/lib/interactive/FibonacciRetracement.jsx
+++ b/src/lib/interactive/FibonacciRetracement.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { isDefined, isNotDefined, head, last, noop } from "../utils";
 

--- a/src/lib/interactive/InteractiveLine.jsx
+++ b/src/lib/interactive/InteractiveLine.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { select, event as d3Event } from "d3-selection";
 

--- a/src/lib/interactive/MouseLocationIndicator.jsx
+++ b/src/lib/interactive/MouseLocationIndicator.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import GenericChartComponent from "../GenericChartComponent";
 

--- a/src/lib/interactive/TrendLine.jsx
+++ b/src/lib/interactive/TrendLine.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { isDefined, isNotDefined, noop } from "../utils";
 

--- a/src/lib/series/AreaOnlySeries.jsx
+++ b/src/lib/series/AreaOnlySeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { area as d3Area } from "d3-shape";
 
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";

--- a/src/lib/series/AreaSeries.jsx
+++ b/src/lib/series/AreaSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 
 import LineSeries from "./LineSeries";
 import AreaOnlySeries from "./AreaOnlySeries";

--- a/src/lib/series/BarSeries.jsx
+++ b/src/lib/series/BarSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";
 

--- a/src/lib/series/BollingerSeries.jsx
+++ b/src/lib/series/BollingerSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import LineSeries from "./LineSeries";
 import AreaOnlySeries from "./AreaOnlySeries";

--- a/src/lib/series/CandlestickSeries.jsx
+++ b/src/lib/series/CandlestickSeries.jsx
@@ -2,7 +2,8 @@
 
 import { nest } from "d3-collection";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";
 import { first, last, hexToRGBA, isDefined, functor } from "../utils";

--- a/src/lib/series/CircleMarker.jsx
+++ b/src/lib/series/CircleMarker.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 
 import { hexToRGBA, functor } from "../utils";
 

--- a/src/lib/series/ElderRaySeries.jsx
+++ b/src/lib/series/ElderRaySeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import OverlayBarSeries from "./OverlayBarSeries";
 import StraightLine from "./StraightLine";

--- a/src/lib/series/GroupedBarSeries.jsx
+++ b/src/lib/series/GroupedBarSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";
 import StackedBarSeries, { drawOnCanvasHelper, svgHelper, identityStack } from "./StackedBarSeries";

--- a/src/lib/series/KagiSeries.jsx
+++ b/src/lib/series/KagiSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { line, curveStepBefore } from "d3-shape";
 
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";

--- a/src/lib/series/LineSeries.jsx
+++ b/src/lib/series/LineSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { line as d3Line } from "d3-shape";
 
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";

--- a/src/lib/series/MACDSeries.jsx
+++ b/src/lib/series/MACDSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import BarSeries from "./BarSeries";
 import LineSeries from "./LineSeries";

--- a/src/lib/series/OHLCSeries.jsx
+++ b/src/lib/series/OHLCSeries.jsx
@@ -1,7 +1,8 @@
 "use strict";
 
 import { nest } from "d3-collection";
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";
 
 import { isDefined, functor } from "../utils";

--- a/src/lib/series/OverlayBarSeries.jsx
+++ b/src/lib/series/OverlayBarSeries.jsx
@@ -2,7 +2,8 @@
 
 import { merge } from "d3-array";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";
 
 import { drawOnCanvas2, getBarsSVG2 } from "./StackedBarSeries";

--- a/src/lib/series/PointAndFigureSeries.jsx
+++ b/src/lib/series/PointAndFigureSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";
 
 import { isDefined, isNotDefined } from "../utils";

--- a/src/lib/series/RSISeries.jsx
+++ b/src/lib/series/RSISeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import LineSeries from "./LineSeries";
 import StraightLine from "./StraightLine";
 

--- a/src/lib/series/RenkoSeries.jsx
+++ b/src/lib/series/RenkoSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";
 
 import { isDefined } from "../utils";

--- a/src/lib/series/SARSeries.jsx
+++ b/src/lib/series/SARSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";
 import { first, last, hexToRGBA } from "../utils";

--- a/src/lib/series/ScatterSeries.jsx
+++ b/src/lib/series/ScatterSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { nest as d3Nest } from "d3-collection";
 
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";

--- a/src/lib/series/SquareMarker.jsx
+++ b/src/lib/series/SquareMarker.jsx
@@ -1,5 +1,6 @@
 "use strict";
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { hexToRGBA, functor } from "../utils";
 
 function Square(props) {

--- a/src/lib/series/StackedBarSeries.jsx
+++ b/src/lib/series/StackedBarSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { nest as d3Nest } from "d3-collection";
 import { merge } from "d3-array";

--- a/src/lib/series/StochasticSeries.jsx
+++ b/src/lib/series/StochasticSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import LineSeries from "./LineSeries";
 import StraightLine from "./StraightLine";

--- a/src/lib/series/StraightLine.jsx
+++ b/src/lib/series/StraightLine.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { hexToRGBA, isDefined, isNotDefined, strokeDashTypes, getStrokeDasharray } from "../utils";
 import GenericChartComponent, { getAxisCanvas } from "../GenericChartComponent";

--- a/src/lib/series/TriangleMarker.jsx
+++ b/src/lib/series/TriangleMarker.jsx
@@ -1,5 +1,6 @@
 "use strict";
-import React, { PropTypes } from "react";
+import React from "react";
+import PropTypes from "prop-types";
 import { hexToRGBA, functor } from "../utils";
 
 function Triangle(props) {

--- a/src/lib/series/VolumeProfileSeries.jsx
+++ b/src/lib/series/VolumeProfileSeries.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import { ascending, descending, sum, max, merge, zip, histogram as d3Histogram } from "d3-array";
 import { nest } from "d3-collection";

--- a/src/lib/tooltip/BollingerBandTooltip.jsx
+++ b/src/lib/tooltip/BollingerBandTooltip.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { format } from "d3-format";
 
 import GenericChartComponent from "../GenericChartComponent";

--- a/src/lib/tooltip/HoverTooltip.jsx
+++ b/src/lib/tooltip/HoverTooltip.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import GenericComponent from "../GenericComponent";
 import { sum } from "d3-array";
 

--- a/src/lib/tooltip/MACDTooltip.jsx
+++ b/src/lib/tooltip/MACDTooltip.jsx
@@ -1,7 +1,8 @@
 "use strict";
 
 import { format } from "d3-format";
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import GenericChartComponent from "../GenericChartComponent";
 
 import ToolTipText from "./ToolTipText";

--- a/src/lib/tooltip/MovingAverageTooltip.jsx
+++ b/src/lib/tooltip/MovingAverageTooltip.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { format } from "d3-format";
 import GenericChartComponent from "../GenericChartComponent";
 

--- a/src/lib/tooltip/OHLCTooltip.jsx
+++ b/src/lib/tooltip/OHLCTooltip.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { format } from "d3-format";
 import { timeFormat } from "d3-time-format";
 

--- a/src/lib/tooltip/RSITooltip.jsx
+++ b/src/lib/tooltip/RSITooltip.jsx
@@ -1,7 +1,8 @@
 "use strict";
 
 import { format } from "d3-format";
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 import GenericChartComponent from "../GenericChartComponent";
 

--- a/src/lib/tooltip/SingleValueTooltip.jsx
+++ b/src/lib/tooltip/SingleValueTooltip.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import { format } from "d3-format";
 
 import GenericChartComponent from "../GenericChartComponent";

--- a/src/lib/tooltip/StochasticTooltip.jsx
+++ b/src/lib/tooltip/StochasticTooltip.jsx
@@ -1,7 +1,8 @@
 "use strict";
 
 import { format } from "d3-format";
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 import GenericChartComponent from "../GenericChartComponent";
 
 import { functor } from "../utils";

--- a/src/lib/tooltip/ToolTipTSpanLabel.jsx
+++ b/src/lib/tooltip/ToolTipTSpanLabel.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 class ToolTipTSpanLabel extends Component {
 	render() {

--- a/src/lib/tooltip/ToolTipText.jsx
+++ b/src/lib/tooltip/ToolTipText.jsx
@@ -1,6 +1,7 @@
 "use strict";
 
-import React, { PropTypes, Component } from "react";
+import React, { Component } from "react";
+import PropTypes from "prop-types";
 
 class ToolTipText extends Component {
 	render() {


### PR DESCRIPTION
from React ## 15.5.7

* **Critical Bugfix:** Fix an accidental breaking change that caused errors in production when used through `React.PropTypes`.

And please see this file
```
docs/lib/charts/CandleStickChartWithEdge_Orig.jsx ( line 115, 116 and 120 )
```

i found error and revert it to #9c087389b9004821bfa953ff83dcb45c44d3636d revision