### PR TITLE
Added touch support to the axis zoom

### DIFF
--- a/src/lib/EventCapture.jsx
+++ b/src/lib/EventCapture.jsx
@@ -3,9 +3,8 @@
 import React, { PropTypes, Component } from "react";
 import { select, event as d3Event } from "d3-selection";
 
-import { isDefined, mousePosition, touchPosition, d3Window, MOUSEMOVE, MOUSEUP } from "./utils";
+import { isDefined, mousePosition, touchPosition, d3Window, MOUSEMOVE, MOUSEUP, getTouchProps } from "./utils";
 import { getCurrentCharts } from "./utils/ChartDataUtil";
-import { getTouchProps } from "./utils";
 
 
 class EventCapture extends Component {

--- a/src/lib/EventCapture.jsx
+++ b/src/lib/EventCapture.jsx
@@ -5,16 +5,8 @@ import { select, event as d3Event } from "d3-selection";
 
 import { isDefined, mousePosition, touchPosition, d3Window, MOUSEMOVE, MOUSEUP } from "./utils";
 import { getCurrentCharts } from "./utils/ChartDataUtil";
+import { getTouchProps } from "./utils";
 
-function getTouchProps(touch) {
-	if (!touch) return {};
-	return {
-		pageX: touch.pageX,
-		pageY: touch.pageY,
-		clientX: touch.clientX,
-		clientY: touch.clientY
-	};
-}
 
 class EventCapture extends Component {
 	constructor(props) {

--- a/src/lib/axes/AxisZoomCapture.jsx
+++ b/src/lib/axes/AxisZoomCapture.jsx
@@ -170,6 +170,7 @@ class AxisZoomCapture extends Component {
 	}
 
 	handleTouchDrag(e) {
+		var e = d3Event;
 		e.preventDefault();
 
 		var { startPosition } = this.state;
@@ -205,6 +206,7 @@ class AxisZoomCapture extends Component {
 
 		if (!this.dragHappened) {
 			if (this.clicked) {
+				var e = d3Event;
 				var touch = getTouchProps(e.touches[0]);
 				var mouseXY = (0, touchPosition)(touch, e, this.node.getBoundingClientRect());
 				var onDoubleClick = this.props.onDoubleClick;

--- a/src/lib/axes/AxisZoomCapture.jsx
+++ b/src/lib/axes/AxisZoomCapture.jsx
@@ -15,7 +15,8 @@ import {
 	MOUSEUP,
 	TOUCHMOVE,
 	TOUCHEND,
-	getTouchProps
+	getTouchProps,
+	touchPosition
 } from "../utils";
 
 function sign(x) {
@@ -140,7 +141,7 @@ class AxisZoomCapture extends Component {
 		});
 	}
 
-	handleTouchStart(e){
+	handleTouchStart(e) {
 		var { getScale, getMoreProps } = this.props;
 		var startScale = getScale(getMoreProps());
 		this.dragHappened = false;
@@ -154,7 +155,7 @@ class AxisZoomCapture extends Component {
 			var startXY = (0, touchPosition)(touch, e);
 
 			var leftX = touch.pageX - startXY[0],
-					topY = touch.pageY - startXY[1];
+				topY = touch.pageY - startXY[1];
 
 			this.setState({
 				startPosition: {
@@ -168,8 +169,7 @@ class AxisZoomCapture extends Component {
 		e.preventDefault();
 	}
 
-	handleTouchDrag(e){
-		var e = d3Event;
+	handleTouchDrag(e) {
 		e.preventDefault();
 
 		var { startPosition } = this.state;
@@ -201,19 +201,18 @@ class AxisZoomCapture extends Component {
 		}
 	}
 
-	handleTouchDragEnd(e){
+	handleTouchDragEnd(e) {
 
 		if (!this.dragHappened) {
 			if (this.clicked) {
-				var e = d3Event
 				var touch = getTouchProps(e.touches[0]);
-				var mouseXY = (0, touchPosition)(touch, e, his.node.getBoundingClientRect());
+				var mouseXY = (0, touchPosition)(touch, e, this.node.getBoundingClientRect());
 				var onDoubleClick = this.props.onDoubleClick;
 				onDoubleClick(mouseXY, e);
 			} else {
 				this.clicked = true;
-				setTimeout(function () {
-					_this2.clicked = false;
+				setTimeout(function() {
+					this.clicked = false;
 				}, 300);
 			}
 		}
@@ -240,6 +239,7 @@ class AxisZoomCapture extends Component {
 			x={bg.x} y={bg.y} opacity={0} height={bg.h} width={bg.w}
 			onContextMenu={this.handleRightClick}
 			onMouseDown={this.handleDragStart}
+			onTouchStart={this.handleTouchStart}
 			/>;
 	}
 }

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -79,6 +79,8 @@ export function d3Window(node) {
 
 export const MOUSEMOVE = "mousemove.pan";
 export const MOUSEUP = "mouseup.pan";
+export const TOUCHMOVE = "touchmove.drag";
+export const TOUCHEND = "touchend.drag";
 
 export function getClosestItemIndexes(array, value, accessor, log) {
 	var lo = 0, hi = array.length - 1;
@@ -222,4 +224,14 @@ export function hexToRGBA(inputHex, opacity) {
 		return result;
 	}
 	return inputHex;
+}
+
+export function getTouchProps(touch) {
+	if (!touch) return {};
+	return {
+		pageX: touch.pageX,
+		pageY: touch.pageY,
+		clientX: touch.clientX,
+		clientY: touch.clientY
+	};
 }


### PR DESCRIPTION
I quickly put together this code to add touch support to axis. I was testing the library out on an UIWebView and noticed I couldn't adjust the zoom by dragging the x or y axis. The feature already existed through mouse events, it was just missing hooks to touch events. 