### PR TITLE
Configurable bar width function

### DIFF
--- a/docs/lib/charts/CandleStickChart.jsx
+++ b/docs/lib/charts/CandleStickChart.jsx
@@ -4,12 +4,13 @@ import React from "react";
 import PropTypes from "prop-types";
 
 import { scaleTime } from "d3-scale";
+import { utcDay } from "d3-time";
 
 import { ChartCanvas, Chart } from "react-stockcharts";
 import { CandlestickSeries } from "react-stockcharts/lib/series";
 import { XAxis, YAxis } from "react-stockcharts/lib/axes";
 import { fitWidth } from "react-stockcharts/lib/helper";
-import { last } from "react-stockcharts/lib/utils";
+import { last, timeIntervalBarWidth } from "react-stockcharts/lib/utils";
 
 class CandleStickChart extends React.Component {
 	render() {
@@ -34,7 +35,7 @@ class CandleStickChart extends React.Component {
 				<Chart id={1} yExtents={d => [d.high, d.low]}>
 					<XAxis axisAt="bottom" orient="bottom" ticks={6}/>
 					<YAxis axisAt="left" orient="left" ticks={5} />
-					<CandlestickSeries />
+					<CandlestickSeries width={timeIntervalBarWidth(utcDay)}/>
 				</Chart>
 			</ChartCanvas>
 		);

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "d3-scale": "^1.0.5",
     "d3-selection": "^1.0.5",
     "d3-shape": "^1.0.6",
+    "d3-time": "^1.0.6",
     "d3-time-format": "^2.0.5",
     "d3fc-rebind": "^4.1.1",
     "debug": "^2.6.6",

--- a/src/lib/series/BarSeries.jsx
+++ b/src/lib/series/BarSeries.jsx
@@ -58,6 +58,7 @@ BarSeries.propTypes = {
 		PropTypes.func,
 	]).isRequired,
 	stroke: PropTypes.bool.isRequired,
+	width: PropTypes.func.isRequired,
 	widthRatio: PropTypes.number.isRequired,
 	yAccessor: PropTypes.func.isRequired,
 	opacity: PropTypes.number.isRequired,
@@ -86,14 +87,14 @@ export default BarSeries;
  to create bars
 */
 function getBars(props, moreProps) {
-	const { baseAt, fill, stroke, widthRatio, yAccessor } = props;
+	const { baseAt, fill, stroke, width, widthRatio, yAccessor } = props;
 	const { xScale, xAccessor, plotData, chartConfig: { yScale } } = moreProps;
 
 	const getFill = functor(fill);
 	const getBase = functor(baseAt);
 
-	const width = Math.abs(xScale(xAccessor(last(plotData))) - xScale(xAccessor(head(plotData))));
-	const bw = (width / (plotData.length - 1) * widthRatio);
+	const baseWidth = width(xScale, xAccessor, plotData);
+	const bw = (baseWidth * widthRatio);
 	const barWidth = Math.round(bw);
 	const offset = (barWidth === 1 ? 0 : 0.5 * bw);
 

--- a/src/lib/series/BarSeries.jsx
+++ b/src/lib/series/BarSeries.jsx
@@ -58,8 +58,10 @@ BarSeries.propTypes = {
 		PropTypes.func,
 	]).isRequired,
 	stroke: PropTypes.bool.isRequired,
-	width: PropTypes.func.isRequired,
-	widthRatio: PropTypes.number.isRequired,
+	width: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.func
+	]).isRequired,
 	yAccessor: PropTypes.func.isRequired,
 	opacity: PropTypes.number.isRequired,
 	fill: PropTypes.oneOfType([
@@ -87,16 +89,21 @@ export default BarSeries;
  to create bars
 */
 function getBars(props, moreProps) {
-	const { baseAt, fill, stroke, width, widthRatio, yAccessor } = props;
+	const { baseAt, fill, stroke, yAccessor } = props;
 	const { xScale, xAccessor, plotData, chartConfig: { yScale } } = moreProps;
 
 	const getFill = functor(fill);
 	const getBase = functor(baseAt);
 
-	const baseWidth = width(xScale, xAccessor, plotData);
-	const bw = (baseWidth * widthRatio);
-	const barWidth = Math.round(bw);
-	const offset = (barWidth === 1 ? 0 : 0.5 * bw);
+	const widthFunctor = functor(props.width);
+	const width = widthFunctor(props, {
+		xScale,
+		xAccessor,
+		plotData
+	});
+
+	const barWidth = Math.round(width);
+	const offset = (barWidth === 1 ? 0 : 0.5 * barWidth);
 
 	const bars = plotData
 		.map(d => {

--- a/src/lib/series/BarSeries.jsx
+++ b/src/lib/series/BarSeries.jsx
@@ -14,7 +14,7 @@ import StackedBarSeries, {
 	// identityStack
 } from "./StackedBarSeries";
 
-import { functor, last, head } from "../utils";
+import { functor } from "../utils";
 
 class BarSeries extends Component {
 	constructor(props) {

--- a/src/lib/series/CandlestickSeries.jsx
+++ b/src/lib/series/CandlestickSeries.jsx
@@ -8,7 +8,7 @@ import PropTypes from "prop-types";
 import GenericChartComponent from "../GenericChartComponent";
 import { getAxisCanvas } from "../GenericComponent";
 
-import { head, last, hexToRGBA, isDefined, functor } from "../utils";
+import { hexToRGBA, isDefined, functor, plotDataLengthBarWidth } from "../utils";
 
 class CandlestickSeries extends Component {
 	constructor(props) {
@@ -51,6 +51,7 @@ CandlestickSeries.propTypes = {
 	className: PropTypes.string,
 	wickClassName: PropTypes.string,
 	candleClassName: PropTypes.string,
+	width: PropTypes.func.isRequired,
 	widthRatio: PropTypes.number.isRequired,
 	classNames: PropTypes.oneOfType([
 		PropTypes.func,
@@ -78,6 +79,7 @@ CandlestickSeries.defaultProps = {
 	candleClassName: "react-stockcharts-candlestick-candle",
 	yAccessor: d => ({ open: d.open, high: d.high, low: d.low, close: d.close }),
 	classNames: d => d.close > d.open ? "up" : "down",
+	width: plotDataLengthBarWidth,
 	widthRatio: 0.8,
 	wickStroke: "#000000",
 	// wickStroke: d => d.close > d.open ? "#6BA583" : "#FF0000",
@@ -254,15 +256,14 @@ function getCandleData(props, xAccessor, xScale, yScale, plotData) {
 	const { wickStroke: wickStrokeProp } = props;
 	const wickStroke = functor(wickStrokeProp);
 
-	const { classNames, fill: fillProp, stroke: strokeProp, widthRatio, yAccessor } = props;
+	const { classNames, fill: fillProp, stroke: strokeProp, width, widthRatio, yAccessor } = props;
 	const className = functor(classNames);
 
 	const fill = functor(fillProp);
 	const stroke = functor(strokeProp);
 
-	const width = xScale(xAccessor(last(plotData)))
-		- xScale(xAccessor(head(plotData)));
-	const cw = (width / (plotData.length - 1) * widthRatio);
+	const baseWidth = width(xScale, xAccessor, plotData);
+	const cw = baseWidth * widthRatio;
 	const candleWidth = Math.round(cw);
 
 	const offset = (candleWidth === 1 ? 0 : 0.5 * cw);

--- a/src/lib/series/CandlestickSeries.jsx
+++ b/src/lib/series/CandlestickSeries.jsx
@@ -51,8 +51,10 @@ CandlestickSeries.propTypes = {
 	className: PropTypes.string,
 	wickClassName: PropTypes.string,
 	candleClassName: PropTypes.string,
-	width: PropTypes.func.isRequired,
-	widthRatio: PropTypes.number.isRequired,
+	width: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.func
+	]).isRequired,
 	classNames: PropTypes.oneOfType([
 		PropTypes.func,
 		PropTypes.string
@@ -80,7 +82,6 @@ CandlestickSeries.defaultProps = {
 	yAccessor: d => ({ open: d.open, high: d.high, low: d.low, close: d.close }),
 	classNames: d => d.close > d.open ? "up" : "down",
 	width: plotDataLengthBarWidth,
-	widthRatio: 0.8,
 	wickStroke: "#000000",
 	// wickStroke: d => d.close > d.open ? "#6BA583" : "#FF0000",
 	fill: d => d.close > d.open ? "#6BA583" : "#FF0000",
@@ -256,17 +257,22 @@ function getCandleData(props, xAccessor, xScale, yScale, plotData) {
 	const { wickStroke: wickStrokeProp } = props;
 	const wickStroke = functor(wickStrokeProp);
 
-	const { classNames, fill: fillProp, stroke: strokeProp, width, widthRatio, yAccessor } = props;
+	const { classNames, fill: fillProp, stroke: strokeProp, yAccessor } = props;
 	const className = functor(classNames);
 
 	const fill = functor(fillProp);
 	const stroke = functor(strokeProp);
 
-	const baseWidth = width(xScale, xAccessor, plotData);
-	const cw = baseWidth * widthRatio;
-	const candleWidth = Math.round(cw);
+	const widthFunctor = functor(props.width);
+	const width = widthFunctor(props, {
+		xScale,
+		xAccessor,
+		plotData
+	});
 
-	const offset = (candleWidth === 1 ? 0 : 0.5 * cw);
+	const candleWidth = Math.round(width);
+
+	const offset = (candleWidth === 1 ? 0 : 0.5 * width);
 
 	// eslint-disable-next-line prefer-const
 	let candles = [];

--- a/src/lib/series/StackedBarSeries.jsx
+++ b/src/lib/series/StackedBarSeries.jsx
@@ -10,7 +10,7 @@ import { stack as d3Stack } from "d3-shape";
 import GenericChartComponent from "../GenericChartComponent";
 import { getAxisCanvas } from "../GenericComponent";
 
-import { identity, hexToRGBA, head, last, functor } from "../utils";
+import { identity, hexToRGBA, head, functor, plotDataLengthBarWidth } from "../utils";
 
 class StackedBarSeries extends Component {
 	constructor(props) {
@@ -49,6 +49,7 @@ StackedBarSeries.propTypes = {
 	]).isRequired,
 	direction: PropTypes.oneOf(["up", "down"]).isRequired,
 	stroke: PropTypes.bool.isRequired,
+	width: PropTypes.func.isRequired,
 	widthRatio: PropTypes.number.isRequired,
 	opacity: PropTypes.number.isRequired,
 	fill: PropTypes.oneOfType([
@@ -67,6 +68,7 @@ StackedBarSeries.defaultProps = {
 	stroke: true,
 	fill: "#4682B4",
 	opacity: 0.5,
+	width: plotDataLengthBarWidth,
 	widthRatio: 0.8,
 	clip: true,
 };
@@ -215,14 +217,14 @@ export function drawOnCanvas2(props, ctx, bars) {
 }
 
 export function getBars(props, xAccessor, yAccessor, xScale, yScale, plotData, stack = identityStack, after = identity) {
-	const { baseAt, className, fill, stroke, widthRatio, spaceBetweenBar = 0 } = props;
+	const { baseAt, className, fill, stroke, width, widthRatio, spaceBetweenBar = 0 } = props;
 
 	const getClassName = functor(className);
 	const getFill = functor(fill);
 	const getBase = functor(baseAt);
 
-	const width = Math.abs(xScale(xAccessor(last(plotData))) - xScale(xAccessor(head(plotData))));
-	const bw = (width / (plotData.length - 1) * widthRatio);
+	const baseWidth = width(xScale, xAccessor, plotData);
+	const bw = (baseWidth * widthRatio);
 	const barWidth = Math.round(bw);
 	// console.log(barWidth)
 

--- a/src/lib/utils/barWidth.js
+++ b/src/lib/utils/barWidth.js
@@ -3,14 +3,18 @@
 import { head, last } from "../utils";
 
 /**
- * Bar width is based on the amount of items in the plot data and the distance between the first and last of those items.
- * @param scale the scale of the axis.
- * @param accessor the accessor to retrieve the value on the axis.
- * @param plotData the plot data.
+ * Bar width is based on the amount of items in the plot data and the distance between the first and last of those
+ * items.
+ * @param props the props passed to the series.
+ * @param moreProps an object holding the xScale, xAccessor and plotData.
  * @return {number} the bar width.
  */
-export function plotDataLengthBarWidth(scale, accessor, plotData) {
-	return Math.abs((scale(accessor(last(plotData))) - scale(accessor(head(plotData)))) / (plotData.length - 1));
+export function plotDataLengthBarWidth(props, moreProps) {
+	const { widthRatio: widthRatio = 0.8 } = props;
+	const { xScale: scale, xAccessor: accessor, plotData } = moreProps;
+
+	const width = Math.abs((scale(accessor(last(plotData))) - scale(accessor(head(plotData)))) / (plotData.length - 1));
+	return width * widthRatio;
 }
 
 /**
@@ -19,8 +23,11 @@ export function plotDataLengthBarWidth(scale, accessor, plotData) {
  * @return {Function} the width function.
  */
 export function timeIntervalBarWidth(interval) {
-	return function(scale, accessor, plotData) {
+	return function(props, moreProps) {
+		const { widthRatio: widthRatio = 0.8 } = props;
+		const { xScale: scale, xAccessor: accessor, plotData } = moreProps;
+
 		const first = accessor(head(plotData));
-		return Math.abs(scale(interval.offset(first, 1)) - scale(first));
+		return Math.abs(scale(interval.offset(first, 1)) - scale(first)) * widthRatio;
 	};
 }

--- a/src/lib/utils/barWidth.js
+++ b/src/lib/utils/barWidth.js
@@ -1,0 +1,26 @@
+"use strict";
+
+import { head, last } from "../utils";
+
+/**
+ * Bar width is based on the amount of items in the plot data and the distance between the first and last of those items.
+ * @param scale the scale of the axis.
+ * @param accessor the accessor to retrieve the value on the axis.
+ * @param plotData the plot data.
+ * @return {number} the bar width.
+ */
+export function plotDataLengthBarWidth(scale, accessor, plotData) {
+	return Math.abs((scale(accessor(last(plotData))) - scale(accessor(head(plotData)))) / (plotData.length - 1));
+}
+
+/**
+ * Generates a width function that calculates the bar width based on the given time interval.
+ * @param interval a d3-time time interval.
+ * @return {Function} the width function.
+ */
+export function timeIntervalBarWidth(interval) {
+	return function(scale, accessor, plotData) {
+		const first = accessor(head(plotData));
+		return Math.abs(scale(interval.offset(first, 1)) - scale(first));
+	};
+}

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -15,6 +15,7 @@ export { default as mappedSlidingWindow } from "./mappedSlidingWindow";
 export { default as accumulatingWindow } from "./accumulatingWindow";
 export { default as PureComponent } from "./PureComponent";
 
+export * from "./barWidth";
 export * from "./strokeDasharray";
 
 export function getLogger(prefix) {


### PR DESCRIPTION
I came across issue #142 the other day because my data is relatively sparse and irregular but my use-case doesn't allow the use of a `discontinuousTimeScaleProvider`. The workaround described in #142 (fiddling with widthRatio) exposes too many things that should stay internal, imo.

So I tried to come up with a better solution. Initially, I just wanted to add a time interval prop to the respective series, but I figured that's an implementation detail and only applies to certain types of axes, so I instead opted for an approach where one can pass a width function to the series which allows to implement arbitrary logic to come up with a bar width. 

* The function is passed the y-scale, y-accessor and plot data.
* The current behavior is still the default by providing the respective implementation as a default prop.
* I implemented a proof-of-concept interval-based function based on my use-case.
* I added the interval-based implementation to the first example in the Candlestick Chart example in the documentation where is already keeps bars from overlapping.
* Currently, CandlestickSeries, BarSeries and StackedBarSeries have been adjusted.
* widthRatio is still used adjust the final bar width. I'm undecided whether this should be an implementation detail of the width function as well or be kept separate.

Please let me know what you think. If you like my proposal, I would greatly appreciate a quick merge. I'm having a few issues running my fork in my project 😄 