### PR TITLE
Modified getNewShartConfig to account for webpack bug

### DIFF
--- a/src/lib/utils/ChartDataUtil.js
+++ b/src/lib/utils/ChartDataUtil.js
@@ -46,7 +46,7 @@ function values(func) {
 export function getNewChartConfig(innerDimension, children) {
 
 	return React.Children.map(children, (each) => {
-		if (each.type === Chart) {
+		if (each.type.toString() === Chart.toString()) {
 			var { id, origin, padding, yExtents: yExtentsProp, yScale, flipYScale, yExtentsCalculator } = each.props;
 			var { width, height, availableWidth, availableHeight } = getDimensions(innerDimension, each.props);
 			var { yPan } = each.props;


### PR DESCRIPTION
Webpack's code compiling can cause a direct check of each.tpye === Chart to fail.
This patch converts the two functions two strings so that it does not rely on them
being the same object only functionally equivalent.