### PR TITLE
Modified getNewShartConfig to account for webpack bug

### DIFF
--- a/src/lib/utils/ChartDataUtil.js
+++ b/src/lib/utils/ChartDataUtil.js
@@ -45,7 +45,7 @@ function values(func) {
 export function getNewChartConfig(innerDimension, children) {
 
 	return React.Children.map(children, (each) => {
-		if (each.type === Chart) {
+		if (each.type.toString() === Chart.toString()) {
 			const chartProps = {
 				...Chart.defaultProps,
 				...each.props


### PR DESCRIPTION
Webpack's code compiling can cause a direct check of each.tpye === Chart to fail.
This patch converts the two functions two strings so that it does not rely on them
being the same object only functionally equivalent.