### PR TITLE
Fix shallowEqual hasOwnProperty check, issue #233

### DIFF
--- a/src/lib/utils/shallowEqual.js
+++ b/src/lib/utils/shallowEqual.js
@@ -41,7 +41,7 @@ export default function shallowEqual(a, b) {
 	let numKeysA = 0, numKeysB = 0, key;
 	for (key in b) {
 		numKeysB++;
-		if (/* !isPrimitive(b[key]) || */ !a.hasOwnProperty(key) || !isEqual(a[key], b[key])) {
+		if (/* !isPrimitive(b[key]) || */ (b.hasOwnProperty(key) && !a.hasOwnProperty(key)) || !isEqual(a[key], b[key])) {
 			// console.log(key, a, b);
 			return false;
 		}


### PR DESCRIPTION
Fixes the issue explained in #233, copying my explanation from that issue:

Since you don't check `hasOwnProperty` on `b`, only on `a`, the prototype methods `__ARRAY__` and `equals` are checked and the `!a.hasOwnProperty(key)` always returns true.