### PR TITLE
Fix propTypes requirement and add some missing propTypes

### DIFF
--- a/src/lib/Chart.js
+++ b/src/lib/Chart.js
@@ -63,7 +63,7 @@ Chart.propTypes = {
 	origin: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.func
-	]).isRequired,
+	]),
 	id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
 	yExtents: PropTypes.oneOfType([
 		PropTypes.array,
@@ -74,17 +74,17 @@ Chart.propTypes = {
 			return new Error("yExtents or yExtentsCalculator must"
 				+ ` be present on ${componentName}. Validation failed.`);
 	},
-	onContextMenu: PropTypes.func.isRequired,
-	yScale: PropTypes.func.isRequired,
+	onContextMenu: PropTypes.func,
+	yScale: PropTypes.func,
 
-	flipYScale: PropTypes.bool.isRequired,
+	flipYScale: PropTypes.bool,
 	padding: PropTypes.oneOfType([
 		PropTypes.number,
 		PropTypes.shape({
 			top: PropTypes.number,
 			bottom: PropTypes.number,
 		})
-	]).isRequired,
+	]),
 	children: PropTypes.node,
 };
 

--- a/src/lib/ChartCanvas.js
+++ b/src/lib/ChartCanvas.js
@@ -1081,7 +1081,7 @@ ChartCanvas.propTypes = {
 	margin: PropTypes.object,
 	ratio: PropTypes.number.isRequired,
 	// interval: PropTypes.oneOf(["D", "W", "M"]), // ,"m1", "m5", "m15", "W", "M"
-	type: PropTypes.oneOf(["svg", "hybrid"]).isRequired,
+	type: PropTypes.oneOf(["svg", "hybrid"]),
 	pointsPerPxThreshold: PropTypes.number,
 	minPointsPerPxThreshold: PropTypes.number,
 	data: PropTypes.array.isRequired,
@@ -1090,26 +1090,26 @@ ChartCanvas.propTypes = {
 	xExtents: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.func
-	]).isRequired,
-	zoomAnchor: PropTypes.func.isRequired,
+	]),
+	zoomAnchor: PropTypes.func,
 
 	className: PropTypes.string,
 	seriesName: PropTypes.string.isRequired,
 	zIndex: PropTypes.number,
 	children: PropTypes.node.isRequired,
 	xScale: PropTypes.func.isRequired,
-	postCalculator: PropTypes.func.isRequired,
-	flipXScale: PropTypes.bool.isRequired,
-	useCrossHairStyleCursor: PropTypes.bool.isRequired,
+	postCalculator: PropTypes.func,
+	flipXScale: PropTypes.bool,
+	useCrossHairStyleCursor: PropTypes.bool,
 	padding: PropTypes.oneOfType([
 		PropTypes.number,
 		PropTypes.shape({
 			left: PropTypes.number,
 			right: PropTypes.number,
 		})
-	]).isRequired,
+	]),
 	defaultFocus: PropTypes.bool,
-	zoomMultiplier: PropTypes.number.isRequired,
+	zoomMultiplier: PropTypes.number,
 	onLoadMore: PropTypes.func,
 	displayXAccessor: function(props, propName/* , componentName */) {
 		if (isNotDefined(props[propName])) {
@@ -1121,10 +1121,10 @@ ChartCanvas.propTypes = {
 			return new Error("displayXAccessor has to be a function");
 		}
 	},
-	mouseMoveEvent: PropTypes.bool.isRequired,
-	panEvent: PropTypes.bool.isRequired,
-	clamp: PropTypes.bool.isRequired,
-	zoomEvent: PropTypes.bool.isRequired,
+	mouseMoveEvent: PropTypes.bool,
+	panEvent: PropTypes.bool,
+	clamp: PropTypes.bool,
+	zoomEvent: PropTypes.bool,
 	onSelect: PropTypes.func,
 };
 

--- a/src/lib/annotation/Annotate.js
+++ b/src/lib/annotation/Annotate.js
@@ -38,7 +38,7 @@ class Annotate extends Component {
 }
 
 Annotate.propTypes = {
-	className: PropTypes.string.isRequired,
+	className: PropTypes.string,
 	with: PropTypes.func,
 	when: PropTypes.func,
 	usingProps: PropTypes.object,

--- a/src/lib/annotation/Label.js
+++ b/src/lib/annotation/Label.js
@@ -41,11 +41,29 @@ function getYScale(chartConfig) {
 
 Label.propTypes = {
 	className: PropTypes.string,
-	selectCanvas: PropTypes.func.isRequired,
+	selectCanvas: PropTypes.func,
 	text: PropTypes.oneOfType([
 		PropTypes.string,
 		PropTypes.func
 	]).isRequired,
+	textAnchor: PropTypes.string,
+	fontFamily: PropTypes.string,
+	fontSize: PropTypes.number,
+	opacity: PropTypes.number,
+	rotate: PropTypes.number,
+	onClick: PropTypes.func,
+	xAccessor: PropTypes.func,
+	xScale: PropTypes.func,
+	yScale: PropTypes.func,
+	datum: PropTypes.object,
+	x: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.func
+	]),
+	y: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.func
+	])
 };
 
 Label.contextTypes = {

--- a/src/lib/annotation/LabelAnnotation.js
+++ b/src/lib/annotation/LabelAnnotation.js
@@ -66,8 +66,14 @@ LabelAnnotation.propTypes = {
 	xScale: PropTypes.func,
 	yScale: PropTypes.func,
 	datum: PropTypes.object,
-	x: PropTypes.func,
-	y: PropTypes.func,
+	x: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.func
+	]),
+	y: PropTypes.oneOfType([
+		PropTypes.number,
+		PropTypes.func
+	])
 };
 
 export const defaultProps = {

--- a/src/lib/axes/XAxis.js
+++ b/src/lib/axes/XAxis.js
@@ -39,7 +39,7 @@ XAxis.propTypes = {
 	tickValues: PropTypes.array,
 	showTicks: PropTypes.bool,
 	className: PropTypes.string,
-	zoomEnabled: PropTypes.bool.isRequired,
+	zoomEnabled: PropTypes.bool,
 	onContextMenu: PropTypes.func,
 	onDoubleClick: PropTypes.func,
 };

--- a/src/lib/axes/YAxis.js
+++ b/src/lib/axes/YAxis.js
@@ -39,7 +39,7 @@ YAxis.propTypes = {
 	tickValues: PropTypes.array,
 	showTicks: PropTypes.bool,
 	className: PropTypes.string,
-	zoomEnabled: PropTypes.bool.isRequired,
+	zoomEnabled: PropTypes.bool,
 	onContextMenu: PropTypes.func,
 	onDoubleClick: PropTypes.func,
 };

--- a/src/lib/coordinates/EdgeIndicator.js
+++ b/src/lib/coordinates/EdgeIndicator.js
@@ -47,23 +47,23 @@ class EdgeIndicator extends Component {
 EdgeIndicator.propTypes = {
 	yAccessor: PropTypes.func,
 
-	type: PropTypes.oneOf(["horizontal"]).isRequired,
+	type: PropTypes.oneOf(["horizontal"]),
 	className: PropTypes.string,
 	fill: PropTypes.oneOfType([
 		PropTypes.string,
 		PropTypes.func,
-	]).isRequired,
+	]),
 	textFill: PropTypes.oneOfType([
 		PropTypes.string,
 		PropTypes.func,
-	]).isRequired,
+	]),
 	itemType: PropTypes.oneOf(["first", "last"]).isRequired,
 	orient: PropTypes.oneOf(["left", "right"]),
 	edgeAt: PropTypes.oneOf(["left", "right"]),
-	displayFormat: PropTypes.func.isRequired,
-	rectHeight: PropTypes.number.isRequired,
-	rectWidth: PropTypes.number.isRequired,
-	arrowWidth: PropTypes.number.isRequired,
+	displayFormat: PropTypes.func,
+	rectHeight: PropTypes.number,
+	rectWidth: PropTypes.number,
+	arrowWidth: PropTypes.number,
 };
 
 EdgeIndicator.defaultProps = {

--- a/src/lib/coordinates/MouseCoordinateX.js
+++ b/src/lib/coordinates/MouseCoordinateX.js
@@ -40,6 +40,17 @@ class MouseCoordinateX extends Component {
 
 MouseCoordinateX.propTypes = {
 	displayFormat: PropTypes.func.isRequired,
+	yAxisPad: PropTypes.number,
+	rectWidth: PropTypes.number,
+	rectHeight: PropTypes.number,
+	orient: PropTypes.oneOf(["bottom", "top", "left", "right"]),
+	at: PropTypes.oneOf(["bottom", "top", "left", "right"]),
+	fill: PropTypes.string,
+	opacity: PropTypes.number,
+	fontFamily: PropTypes.string,
+	fontSize: PropTypes.number,
+	textFill: PropTypes.string,
+	snapX: PropTypes.bool
 };
 
 

--- a/src/lib/coordinates/MouseCoordinateY.js
+++ b/src/lib/coordinates/MouseCoordinateY.js
@@ -40,6 +40,17 @@ class MouseCoordinateY extends Component {
 
 MouseCoordinateY.propTypes = {
 	displayFormat: PropTypes.func.isRequired,
+	yAxisPad: PropTypes.number,
+	rectWidth: PropTypes.number,
+	rectHeight: PropTypes.number,
+	orient: PropTypes.oneOf(["bottom", "top", "left", "right"]),
+	at: PropTypes.oneOf(["bottom", "top", "left", "right"]),
+	dx: PropTypes.number,
+	fill: PropTypes.string,
+	opacity: PropTypes.number,
+	fontFamily: PropTypes.string,
+	fontSize: PropTypes.number,
+	textFill: PropTypes.string,
 };
 
 MouseCoordinateY.defaultProps = {

--- a/src/lib/coordinates/PriceCoordinate.js
+++ b/src/lib/coordinates/PriceCoordinate.js
@@ -34,6 +34,21 @@ class PriceCoordinate extends Component {
 
 PriceCoordinate.propTypes = {
 	displayFormat: PropTypes.func.isRequired,
+	yAxisPad: PropTypes.number,
+	rectWidth: PropTypes.number,
+	rectHeight: PropTypes.number,
+	orient: PropTypes.oneOf(["bottom", "top", "left", "right"]),
+	at: PropTypes.oneOf(["bottom", "top", "left", "right"]),
+	price: PropTypes.number,
+	dx: PropTypes.number,
+	arrowWidth: PropTypes.number,
+	fill: PropTypes.string,
+	opacity: PropTypes.number,
+	lineOpacity: PropTypes.number,
+	lineStroke: PropTypes.string,
+	fontFamily: PropTypes.string,
+	fontSize: PropTypes.number,
+	textFill: PropTypes.string,
 };
 
 PriceCoordinate.defaultProps = {

--- a/src/lib/series/BarSeries.js
+++ b/src/lib/series/BarSeries.js
@@ -62,22 +62,22 @@ BarSeries.propTypes = {
 	baseAt: PropTypes.oneOfType([
 		PropTypes.number,
 		PropTypes.func,
-	]).isRequired,
-	stroke: PropTypes.bool.isRequired,
+	]),
+	stroke: PropTypes.bool,
 	width: PropTypes.oneOfType([
 		PropTypes.number,
 		PropTypes.func
-	]).isRequired,
+	]),
 	yAccessor: PropTypes.func.isRequired,
-	opacity: PropTypes.number.isRequired,
+	opacity: PropTypes.number,
 	fill: PropTypes.oneOfType([
 		PropTypes.func, PropTypes.string
-	]).isRequired,
+	]),
 	className: PropTypes.oneOfType([
 		PropTypes.func, PropTypes.string
-	]).isRequired,
-	clip: PropTypes.bool.isRequired,
-	swapScales: PropTypes.bool.isRequired,
+	]),
+	clip: PropTypes.bool,
+	swapScales: PropTypes.bool,
 };
 
 

--- a/src/lib/series/CandlestickSeries.js
+++ b/src/lib/series/CandlestickSeries.js
@@ -57,25 +57,25 @@ CandlestickSeries.propTypes = {
 	width: PropTypes.oneOfType([
 		PropTypes.number,
 		PropTypes.func
-	]).isRequired,
+	]),
 	classNames: PropTypes.oneOfType([
 		PropTypes.func,
 		PropTypes.string
-	]).isRequired,
+	]),
 	fill: PropTypes.oneOfType([
 		PropTypes.func,
 		PropTypes.string
-	]).isRequired,
+	]),
 	stroke: PropTypes.oneOfType([
 		PropTypes.func,
 		PropTypes.string
-	]).isRequired,
+	]),
 	wickStroke: PropTypes.oneOfType([
 		PropTypes.func,
 		PropTypes.string
-	]).isRequired,
-	yAccessor: PropTypes.func.isRequired,
-	clip: PropTypes.bool.isRequired,
+	]),
+	yAccessor: PropTypes.func,
+	clip: PropTypes.bool,
 };
 
 CandlestickSeries.defaultProps = {

--- a/src/lib/tooltip/OHLCTooltip.js
+++ b/src/lib/tooltip/OHLCTooltip.js
@@ -75,13 +75,13 @@ class OHLCTooltip extends Component {
 
 OHLCTooltip.propTypes = {
 	className: PropTypes.string,
-	accessor: PropTypes.func.isRequired,
-	xDisplayFormat: PropTypes.func.isRequired,
-	ohlcFormat: PropTypes.func.isRequired,
+	accessor: PropTypes.func,
+	xDisplayFormat: PropTypes.func,
+	ohlcFormat: PropTypes.func,
 	origin: PropTypes.oneOfType([
 		PropTypes.array,
 		PropTypes.func
-	]).isRequired,
+	]),
 	fontFamily: PropTypes.string,
 	fontSize: PropTypes.number,
 	onClick: PropTypes.func,


### PR DESCRIPTION
As part of an effort to extract project-wide propTypes into TypeScript definitions, there were numerous corrections needed. They are either:

- Props specified as required that actually aren’t because default prop values are given.
- Missing propTypes

This is the initial round of fixes, more PRs are expected. 