### PR TITLE
Allows for early exit when linearly searching configs

### DIFF
--- a/src/lib/Chart.js
+++ b/src/lib/Chart.js
@@ -37,12 +37,12 @@ class Chart extends PureComponent {
 		}
 	}
 	yScale() {
-		const chartConfig = this.context.chartConfig.filter((each) => each.id === this.props.id)[0];
+		const chartConfig = this.context.chartConfig.find(each => each.id === this.props.id);
 		return chartConfig.yScale.copy();
 	}
 	getChildContext() {
 		const { id: chartId } = this.props;
-		const chartConfig = this.context.chartConfig.filter((each) => each.id === chartId)[0];
+		const chartConfig = this.context.chartConfig.find(each => each.id === this.props.id);
 
 		return {
 			chartId,
@@ -50,7 +50,7 @@ class Chart extends PureComponent {
 		};
 	}
 	render() {
-		const { origin } = this.context.chartConfig.filter((each) => each.id === this.props.id)[0];
+		const { origin } = this.context.chartConfig.find(each => each.id === this.props.id);
 		const [x, y] = origin;
 
 		return <g transform={`translate(${ x }, ${ y })`}>{this.props.children}</g>;

--- a/src/lib/GenericChartComponent.js
+++ b/src/lib/GenericChartComponent.js
@@ -59,7 +59,7 @@ class GenericChartComponent extends GenericComponent {
 		if (chartConfigList) {
 			const { chartId } = this.context;
 			const chartConfig = chartConfigList
-				.filter(each => each.id === chartId)[0];
+				.find(each => each.id === chartId);
 			this.moreProps.chartConfig = chartConfig;
 		}
 		if (isDefined(this.moreProps.chartConfig)) {

--- a/src/lib/interactive/utils.js
+++ b/src/lib/interactive/utils.js
@@ -63,7 +63,7 @@ function getMouseXY(moreProps, [ox, oy]) {
 export function getMorePropsForChart(moreProps, chartId) {
 	const { chartConfig: chartConfigList } = moreProps;
 	const chartConfig = chartConfigList
-		.filter(each => each.id === chartId)[0];
+		.find(each => each.id === chartId);
 
 	const { origin } = chartConfig;
 	const mouseXY = getMouseXY(moreProps, origin);


### PR DESCRIPTION
I noticed these lines and thought I'd write a quick fix. By using find, the loop early exits instead of doing a full search.