### PR TITLE
Adds find() polyfill allowing for a linear search with early exit in all browsers

### DIFF
--- a/src/lib/Chart.js
+++ b/src/lib/Chart.js
@@ -4,7 +4,11 @@ import PropTypes from "prop-types";
 import { scaleLinear } from "d3-scale";
 
 import PureComponent from "./utils/PureComponent";
-import { isNotDefined, noop } from "./utils";
+import {
+	isNotDefined,
+	noop,
+	find,
+} from "./utils";
 
 class Chart extends PureComponent {
 	constructor(props, context) {
@@ -37,12 +41,12 @@ class Chart extends PureComponent {
 		}
 	}
 	yScale() {
-		const chartConfig = this.context.chartConfig.filter((each) => each.id === this.props.id)[0];
+		const chartConfig = find(this.context.chartConfig, each => each.id === this.props.id);
 		return chartConfig.yScale.copy();
 	}
 	getChildContext() {
 		const { id: chartId } = this.props;
-		const chartConfig = this.context.chartConfig.filter((each) => each.id === chartId)[0];
+		const chartConfig = find(this.context.chartConfig, each => each.id === chartId);
 
 		return {
 			chartId,
@@ -50,7 +54,7 @@ class Chart extends PureComponent {
 		};
 	}
 	render() {
-		const { origin } = this.context.chartConfig.filter((each) => each.id === this.props.id)[0];
+		const { origin } = find(this.context.chartConfig, each => each.id === this.props.id);
 		const [x, y] = origin;
 
 		return <g transform={`translate(${ x }, ${ y })`}>{this.props.children}</g>;

--- a/src/lib/GenericChartComponent.js
+++ b/src/lib/GenericChartComponent.js
@@ -4,6 +4,7 @@ import PropTypes from "prop-types";
 import GenericComponent from "./GenericComponent";
 import {
 	isDefined,
+	find,
 } from "./utils";
 
 const ALWAYS_TRUE_TYPES = [
@@ -58,8 +59,7 @@ class GenericChartComponent extends GenericComponent {
 
 		if (chartConfigList) {
 			const { chartId } = this.context;
-			const chartConfig = chartConfigList
-				.filter(each => each.id === chartId)[0];
+			const chartConfig = find(chartConfigList, each => each.id === chartConfigList);
 			this.moreProps.chartConfig = chartConfig;
 		}
 		if (isDefined(this.moreProps.chartConfig)) {

--- a/src/lib/interactive/utils.js
+++ b/src/lib/interactive/utils.js
@@ -1,4 +1,9 @@
-import { isNotDefined, isDefined, mapObject } from "../utils";
+import {
+	isNotDefined,
+	isDefined,
+	mapObject,
+	find,
+} from "../utils";
 
 export function getValueFromOverride(override, index, key, defaultValue) {
 	if (isDefined(override) && override.index === index)
@@ -62,8 +67,7 @@ function getMouseXY(moreProps, [ox, oy]) {
 
 export function getMorePropsForChart(moreProps, chartId) {
 	const { chartConfig: chartConfigList } = moreProps;
-	const chartConfig = chartConfigList
-		.filter(each => each.id === chartId)[0];
+	const chartConfig = find(chartConfigList, each => each.id === chartId);
 
 	const { origin } = chartConfig;
 	const mouseXY = getMouseXY(moreProps, origin);

--- a/src/lib/utils/index.js
+++ b/src/lib/utils/index.js
@@ -81,6 +81,15 @@ export function getClosestValue(inputValue, currentValue) {
 	return currentValue + diff;
 }
 
+export function find(list, predicate, context=this) {
+	for (let i = 0; i < list.length; ++i) {
+		if (predicate.call(context, list[i], i, list)) {
+			return list[i];
+		}
+	}
+	return undefined;
+}
+
 export function d3Window(node) {
 	const d3win = node
 		&& (node.ownerDocument && node.ownerDocument.defaultView
@@ -249,15 +258,6 @@ export function hexToRGBA(inputHex, opacity) {
 		return result;
 	}
 	return inputHex;
-}
-
-export function findItem(array, predicate) {
-	for (let i = 0; i < array.length; i++) {
-		const each = array[i];
-		if (predicate(each)) {
-			return each;
-		}
-	}
 }
 
 export function toObject(array, iteratee) {


### PR DESCRIPTION
This is an update based on https://github.com/rrag/react-stockcharts/pull/348.

It's worth noting that this also removes the findItem() function. It wasn't up to spec with the native Javascript Array.prototype.find (lacking the ability to override the context of the predicate) and it wasn't being used anywhere in the codebase.

Hopefully this looks good @rrag 