### PR TITLE
Fixed tickInterval to dynamically adapt to domain

### DIFF
--- a/src/lib/axes/Axis.js
+++ b/src/lib/axes/Axis.js
@@ -134,7 +134,7 @@ function tickHelper(props, scale) {
 		tickValues = tickValuesProp;
 	} else if (isDefined(tickInterval)) {
 		const [min, max] = scale.domain();
-		tickValues = d3Range(min, max, tickInterval);
+		tickValues = d3Range(min, max, (max-min) / tickInterval);
 	} else if (isDefined(scale.ticks)) {
 		tickValues = scale.ticks(tickArguments, flexTicks);
 	} else {


### PR DESCRIPTION
Currently, the `tickInterval` option on the `XAxis` and `YAxis` expects a hard coded value which is totally unaware of the domain. 
My understanding is the `tickInterval` should force the domain to be divided in the exact number supplied by `tickInterval` hence the slight modification in code.