### PR TITLE
Added `tickLabelFill` to SVG render

### DIFF
--- a/src/lib/axes/Axis.js
+++ b/src/lib/axes/Axis.js
@@ -296,7 +296,6 @@ function drawAxisLine(ctx, props, range) {
 
 function Tick(props) {
 	const { tickLabelFill, tickStroke, tickStrokeOpacity, tickStrokeDasharray, tickStrokeWidth, textAnchor, fontSize, fontFamily } = props;
-  console.log(tickLabelFill);
 	const { x1, y1, x2, y2, labelX, labelY, dy } = props;
 	return (
 		<g className="tick">

--- a/src/lib/axes/Axis.js
+++ b/src/lib/axes/Axis.js
@@ -295,7 +295,8 @@ function drawAxisLine(ctx, props, range) {
 }
 
 function Tick(props) {
-	const { tickStroke, tickStrokeOpacity, tickStrokeDasharray, tickStrokeWidth, textAnchor, fontSize, fontFamily } = props;
+	const { tickLabelFill, tickStroke, tickStrokeOpacity, tickStrokeDasharray, tickStrokeWidth, textAnchor, fontSize, fontFamily } = props;
+  console.log(tickLabelFill);
 	const { x1, y1, x2, y2, labelX, labelY, dy } = props;
 	return (
 		<g className="tick">
@@ -309,7 +310,7 @@ function Tick(props) {
 				x2={x2} y2={y2} />
 			<text
 				dy={dy} x={labelX} y={labelY}
-				fill={tickStroke}
+				fill={tickLabelFill}
 				fontSize={fontSize}
 				fontFamily={fontFamily}
 				textAnchor={textAnchor}>
@@ -340,7 +341,7 @@ Tick.propTypes = {
 function axisTicksSVG(props, scale) {
 	const result = tickHelper(props, scale);
 
-	const { tickStroke, tickStrokeOpacity, tickStrokeWidth, tickStrokeDasharray, textAnchor } = result;
+	const { tickLabelFill, tickStroke, tickStrokeOpacity, tickStrokeWidth, tickStrokeDasharray, textAnchor } = result;
 	const { fontSize, fontFamily, ticks, format } = result;
 
 	const { dy } = result;
@@ -351,6 +352,7 @@ function axisTicksSVG(props, scale) {
 				return (
 					<Tick key={idx}
 						tickStroke={tickStroke}
+						tickLabelFill={tickLabelFill}
 						tickStrokeWidth={tickStrokeWidth}
 						tickStrokeOpacity={tickStrokeOpacity}
 						tickStrokeDasharray={tickStrokeDasharray}


### PR DESCRIPTION
So, the current code only supported `tickLabelFill` for canvas rendering. This patch adds it to the svg rendering :)