### PR TITLE
Clamp tweak

### DIFF
--- a/docs/md/ZOOM-AND-PAN.md
+++ b/docs/md/ZOOM-AND-PAN.md
@@ -6,10 +6,10 @@ Click and drag the axis, to zoom on y & x. Once y axis is zoomed you can pan the
 
 `mousemove`, `pan` and `zoom` are enabled by default. To disable them you can use `mouseMoveEvent`, `panEvent` and `zoomEvent` props.
 
-`clamp` is disabled by default
+`clamp` prevents scrolling past the last data point, and is disabled by default. Supported values for clamp are `left`, `right`, or `both` for clamping one or both sides of the graph.
 
 ```jsx
-<ChartCanvas 
+<ChartCanvas
     ...
     mouseMoveEvent={true}
     panEvent={true}

--- a/src/lib/ChartCanvas.js
+++ b/src/lib/ChartCanvas.js
@@ -1138,7 +1138,7 @@ ChartCanvas.propTypes = {
 	},
 	mouseMoveEvent: PropTypes.bool,
 	panEvent: PropTypes.bool,
-	clamp: PropTypes.bool,
+	clamp: PropTypes.string,
 	zoomEvent: PropTypes.bool,
 	onSelect: PropTypes.func,
 };

--- a/src/lib/scale/evaluator.js
+++ b/src/lib/scale/evaluator.js
@@ -20,13 +20,16 @@ function extentsWrapper(xAccessor, useWholeData, clamp, pointsPerPxThreshold, mi
 		const right = last(inputDomain);
 
 		const filteredData = getFilteredResponse(data, left, right, xAccessor);
-		const clampedDomain = [
-			Math.max(left, xAccessor(first(data))),
-			Math.min(right, xAccessor(last(data)))
-		];
+		let clampedDomain = inputDomain;
+		if (clamp === 'left' || clamp === 'both' || clamp === true) {
+			clampedDomain[0] = Math.max(left, xAccessor(first(data)));
+		}
+		if (clamp === 'right' || clamp === 'both' || clamp === true) {
+			clampedDomain[1] = Math.min(right, xAccessor(last(data)));
+		}
 
 		const realInputDomain = xAccessor === xAccessor
-			? (clamp ? clampedDomain : inputDomain)
+			? clampedDomain
 			: [xAccessor(first(filteredData)), xAccessor(last(filteredData))];
 
 		const xScale = initialXScale.copy().domain(realInputDomain);


### PR DESCRIPTION
I added the ability to clamp only the left or right sides. To do this, I made clamp a string that supports 'left', 'right', and 'both'. I added backwards compatibility for `true` values as well. 