### PR TITLE
make clamping code lint, fix propType for "clamp" prop

### DIFF
--- a/src/lib/ChartCanvas.js
+++ b/src/lib/ChartCanvas.js
@@ -1138,7 +1138,7 @@ ChartCanvas.propTypes = {
 	},
 	mouseMoveEvent: PropTypes.bool,
 	panEvent: PropTypes.bool,
-	clamp: PropTypes.string,
+	clamp: PropTypes.oneOfType([PropTypes.string,PropTypes.bool]),
 	zoomEvent: PropTypes.bool,
 	onSelect: PropTypes.func,
 };

--- a/src/lib/scale/evaluator.js
+++ b/src/lib/scale/evaluator.js
@@ -21,11 +21,11 @@ function extentsWrapper(xAccessor, useWholeData, clamp, pointsPerPxThreshold, mi
 
 		const filteredData = getFilteredResponse(data, left, right, xAccessor);
 		let clampedDomain = inputDomain;
-		if (clamp === 'left' || clamp === 'both' || clamp === true) {
-			clampedDomain[0] = Math.max(left, xAccessor(first(data)));
+		if (clamp === "left" || clamp === "both" || clamp === true) {
+			clampedDomain = [Math.max(left, xAccessor(first(data))), clampedDomain[1]];
 		}
-		if (clamp === 'right' || clamp === 'both' || clamp === true) {
-			clampedDomain[1] = Math.min(right, xAccessor(last(data)));
+		if (clamp === "right" || clamp === "both" || clamp === true) {
+			clampedDomain = [clampedDomain[0], Math.min(right, xAccessor(last(data)))];
 		}
 
 		const realInputDomain = xAccessor === xAccessor


### PR DESCRIPTION
The current master didn't lint and the propType for "clamp" did not match the code (and the defaults did not match) -- both string and boolean are now accepted.

The domain change for clamping was not done in a way compatible with the plugin-const-immutable.
