### PR TITLE
Create GroupTooltip.js

### DIFF
--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -123,38 +123,38 @@ class GroupTooltip extends Component {
         super( props );
         this.renderSVG = this.renderSVG.bind( this );
     }
-    
-    // TODO: please implement this
-    // the retuned x-y-array must have the right x and y
-    // for the translate-property of the groupTooltip-component.
-    getPosition() {
-        const { position } = this.props;
-        let xyPos = [];
 
-        switch ( position ) {
-            case "topLeft":
-                xyPos = [0, 0];
-                break;
+    getPosition(moreProps) {
+        const { position } = this.props;
+        const { height, width } = moreProps.chartConfig;
+
+        const dx = 20;
+        const dy = 40;
+        let textAnchor = null;
+        let xyPos = null;
+        
+        if (position != undefined) {
+            switch ( position ) {
             case "topRight":
-                xyPos = [0, 0];
-                break;
-            case "topCenter":
-                xyPos = [0, 0];
+                xyPos = [width - dx, null];
+                textAnchor = "end";
                 break;
             case "bottomLeft":
-                xyPos = [0, 0];
+                xyPos = [null, height - dy];
                 break;
             case "bottomRight":
-                xyPos = [0, 0];
-                break;
-            case "bottomCenter":
-                xyPos = [0, 0];
+                xyPos = [width - dx, height - dy];
+                textAnchor = "end";
                 break;
             default:
-                xyPos = [0, 0];
+                xyPos = [null, null];
+            }
+        }
+        else{
+            xyPos = [null, null];
         }
 
-        return xyPos;
+        return { xyPos, textAnchor };
     }
     
     
@@ -166,8 +166,10 @@ class GroupTooltip extends Component {
         const { className, onClick, width, verticalSize, fontFamily, fontSize, layout } = this.props;
         const { origin, displayFormat, options } = this.props;
         const currentItem = displayValuesFor( this.props, moreProps );
-        // TODO: implement this.getPosition(props)
-        const xyPos = this.getPosition();
+        const {xyPos, textAnchor} = this.getPosition(moreProps);
+
+        const xPos = xyPos != null && xyPos[0] != null ? xyPos[0] : origin[0];
+        const yPos = xyPos != null && xyPos[1] != null ? xyPos[1] : origin[1];
 
         const singleTooltip = options.map( ( each, idx ) => {
 
@@ -205,8 +207,7 @@ class GroupTooltip extends Component {
         } );
 
         return (
-            // TODO: use xyPos-array for transform-property
-            <g transform={`translate(${origin[0]}, ${origin[1]})`} className={className}>
+            <g transform={`translate(${xPos}, ${yPos})`} className={className} textAnchor={textAnchor}>
                 {layout == "horizontalInline"
                     ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText>
                     : singleTooltip
@@ -231,12 +232,10 @@ GroupTooltip.propTypes = {
         "horizontalInline",
         "vertical",
         "verticalRows"] ).isRequired,
-    // TODO: please implement this
     position: PropTypes.oneOf( [
-        "topLeft",
         "topRight",
         "bottomLeft",
-        "bottomRight"] ).isRequired,
+        "bottomRight"] ),
     displayFormat: PropTypes.func.isRequired,
     origin: PropTypes.array.isRequired,
     displayValuesFor: PropTypes.func,
@@ -259,7 +258,6 @@ GroupTooltip.propTypes = {
 GroupTooltip.defaultProps = {
     className: "react-stockcharts-tooltip react-stockcharts-group-tooltip",
     layout: "horizontal",
-    position: "topLeft",
     displayFormat: format( ".2f" ),
     displayValuesFor: displayValuesFor,
     origin: [0, 0],

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -235,10 +235,8 @@ GroupTooltip.propTypes = {
     position: PropTypes.oneOf( [
         "topLeft",
         "topRight",
-        "topCenter",
         "bottomLeft",
-        "bottomRight",
-        "bottomCenter"] ).isRequired,
+        "bottomRight"] ).isRequired,
     displayFormat: PropTypes.func.isRequired,
     origin: PropTypes.array.isRequired,
     displayValuesFor: PropTypes.func,

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -1,0 +1,225 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { format } from "d3-format";
+import displayValuesFor from "./displayValuesFor";
+import GenericChartComponent from "../GenericChartComponent";
+import ToolTipText from "./ToolTipText";
+import ToolTipTSpanLabel from "./ToolTipTSpanLabel";
+
+import { functor } from "../utils";
+
+class SingleTooltip extends Component {
+    
+    constructor(props) {
+        super(props);
+        this.handleClick = this.handleClick.bind(this);
+    }
+    
+    handleClick(e) {
+        const { onClick, forChart, options } = this.props;
+        onClick({ chartId: forChart, ...options }, e);
+    }
+    
+    /**
+     * Renders the value next to the label.
+     */
+    renderValueNextToLabel(){
+        const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
+
+        return (
+                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
+                {withShape ? <rect x="0" y="-6" width="6" height="6" fill={valueFill} /> : null}
+                <ToolTipText x={withShape ? 8 : 0} y={0} fontFamily={fontFamily} fontSize={fontSize}>
+                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}: </ToolTipTSpanLabel>
+                    <tspan fill={valueFill}>{yValue}</tspan>
+                </ToolTipText>
+                </g>
+               )
+    }
+    
+    /**
+     * Renders the value beneath the label.
+     */
+    renderValueBeneathToLabel(){
+        const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
+
+        return (
+                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
+                {withShape ? <line x1={0} y1={2} x2={0} y2={28} stroke={valueFill} strokeWidth="4px"/> : null}
+                <ToolTipText x={5} y={11} fontFamily={fontFamily} fontSize={fontSize}>
+                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}</ToolTipTSpanLabel>
+                    <tspan x="5" dy="15" fill={valueFill}>{yValue}</tspan>
+                </ToolTipText>
+                </g>
+               )
+    }
+    
+    /**
+     * Renders the value next to the label. 
+     * The parent component must have a "text"-element.
+     */
+    renderInline(){
+        const { yLabel, yValue, labelFill, valueFill, fontSize, fontFamily } = this.props;
+        
+        return (
+                <tspan onClick={this.handleClick} fontFamily={fontFamily} fontSize={fontSize}>
+                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}:&nbsp;</ToolTipTSpanLabel>
+                    <tspan fill={valueFill}>{yValue} &nbsp;&nbsp;</tspan>
+                </tspan>
+               )
+    }
+
+    render() {
+        
+        const { layout } = this.props;
+        let comp = null;
+        
+        switch (layout) {
+            case "horizontal":
+                comp = this.renderValueNextToLabel();
+                break;
+            case "horizontalRows":
+                comp = this.renderValueBeneathToLabel();
+                break;
+            case "horizontalInline":
+                comp = this.renderInline();
+                break;
+            case "vertical":
+                comp = this.renderValueNextToLabel();
+                break;
+            case "verticalRows":
+                comp = this.renderValueBeneathToLabel();
+                break;
+            default:
+                comp = this.renderValueNextToLabel();
+        }
+
+        return comp;
+    }
+}
+
+SingleTooltip.propTypes = {
+        origin: PropTypes.array.isRequired,
+        yLabel: PropTypes.string.isRequired,
+        yValue: PropTypes.string.isRequired,
+        onClick: PropTypes.func,
+        fontFamily: PropTypes.string,
+        labelFill: PropTypes.string.isRequired,
+        valueFill: PropTypes.string.isRequired,
+        fontSize: PropTypes.number,
+        withShape: PropTypes.bool,
+        forChart: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+        options: PropTypes.object.isRequired,
+};
+
+SingleTooltip.defaultProps = {
+        labelFill: "#4682B4",
+        valueFill: "#000000",
+        withShape: false,
+};
+
+class GroupTooltip extends Component {
+    constructor(props) {
+        super(props);
+        this.renderSVG = this.renderSVG.bind(this);
+    }
+    renderSVG(moreProps) {
+        
+        const { displayValuesFor } = this.props;
+        const { chartId } = moreProps;
+
+        const { className, onClick, width, verticalSize, fontFamily, fontSize, layout } = this.props;
+        const { origin, displayFormat, options } = this.props;
+        const currentItem = displayValuesFor(this.props, moreProps);
+        
+        const singleTooltip = options.map((each, idx) => {
+                        
+                    const yValue = currentItem && each.yAccessor(currentItem);
+                    const yDisplayValue = yValue ? displayFormat(yValue) : "n/a";
+
+                    const orig = () => {
+                        if(layout == "horizontal" || layout == "horizontalRows"){
+                            return [width * idx, 0];
+                        }
+                        if(layout == "vertical"){
+                            return [0, verticalSize * idx];
+                        }
+                        if(layout == "verticalRows"){
+                            return [0, verticalSize * 2.3 * idx];
+                        }
+                        return [0, 0];
+                    }
+
+                    return <SingleTooltip
+                            key={idx}
+                            layout={layout}
+                            origin={orig()} 
+                            yLabel={each.yLabel}
+                            yValue={yDisplayValue}
+                            options={each}
+                            forChart={chartId}
+                            onClick={onClick}
+                            fontFamily={fontFamily}
+                            fontSize={fontSize}
+                            labelFill={each.labelFill}
+                            valueFill={each.valueFill}
+                            withShape={each.withShape}
+                            />;
+                });
+        
+        return (
+            <g transform={`translate(${ origin[0] }, ${origin[1] })`} className={className}>
+                {layout == "horizontalInline"
+                    ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText> 
+                    : singleTooltip
+                }
+            </g>
+        );
+    }
+    render() {
+        return <GenericChartComponent
+            clip={false}
+            svgDraw={this.renderSVG}
+            drawOn={["mousemove"]}
+        />;
+    }
+}
+
+GroupTooltip.propTypes = {
+    className: PropTypes.string,
+    layout: PropTypes.oneOf([
+        "horizontal", 
+        "horizontalRows", 
+        "horizontalInline", 
+        "vertical", 
+        "verticalRows"]).isRequired,
+    displayFormat: PropTypes.func.isRequired,
+    origin: PropTypes.array.isRequired,
+    displayValuesFor: PropTypes.func,
+    onClick: PropTypes.func,
+    fontFamily: PropTypes.string,
+    fontSize: PropTypes.number,
+    width: PropTypes.number, // "width" only be used, if layout is "horizontal" or "horizontalRows".
+    verticalSize: PropTypes.number,  // "verticalSize" only be used, if layout is "vertical", "verticalRows".
+    options: PropTypes.arrayOf(PropTypes.shape({
+        yLabel: PropTypes.oneOfType([
+                PropTypes.string,
+                PropTypes.func]).isRequired,
+        yAccessor: PropTypes.func.isRequired,
+        labelFill: PropTypes.string,
+        valueFill: PropTypes.string,
+        withShape: PropTypes.bool, // "withShape" is ignored, if layout is "horizontalInline" or "vertical".
+    })),
+};
+
+GroupTooltip.defaultProps = {
+    className: "react-stockcharts-tooltip react-stockcharts-group-tooltip",
+    layout: "horizontal",
+    displayFormat: format(".2f"),
+    displayValuesFor: displayValuesFor,
+    origin: [0, 0],
+    width: 60, 
+    verticalSize: 13,
+};
+
+export default GroupTooltip;

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -9,72 +9,72 @@ import ToolTipTSpanLabel from "./ToolTipTSpanLabel";
 import { functor } from "../utils";
 
 class SingleTooltip extends Component {
-    
-    constructor(props) {
-        super(props);
-        this.handleClick = this.handleClick.bind(this);
+
+    constructor( props ) {
+        super( props );
+        this.handleClick = this.handleClick.bind( this );
     }
-    
-    handleClick(e) {
+
+    handleClick( e ) {
         const { onClick, forChart, options } = this.props;
-        onClick({ chartId: forChart, ...options }, e);
+        onClick( { chartId: forChart, ...options }, e );
     }
-    
+
     /**
      * Renders the value next to the label.
      */
-    renderValueNextToLabel(){
+    renderValueNextToLabel() {
         const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
 
         return (
-                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
+            <g transform={`translate(${origin[0]}, ${origin[1]})`} onClick={this.handleClick}>
                 {withShape ? <rect x="0" y="-6" width="6" height="6" fill={valueFill} /> : null}
                 <ToolTipText x={withShape ? 8 : 0} y={0} fontFamily={fontFamily} fontSize={fontSize}>
                     <ToolTipTSpanLabel fill={labelFill}>{yLabel}: </ToolTipTSpanLabel>
                     <tspan fill={valueFill}>{yValue}</tspan>
                 </ToolTipText>
-                </g>
-               )
+            </g>
+        )
     }
-    
+
     /**
      * Renders the value beneath the label.
      */
-    renderValueBeneathToLabel(){
+    renderValueBeneathToLabel() {
         const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
 
         return (
-                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
-                {withShape ? <line x1={0} y1={2} x2={0} y2={28} stroke={valueFill} strokeWidth="4px"/> : null}
+            <g transform={`translate(${origin[0]}, ${origin[1]})`} onClick={this.handleClick}>
+                {withShape ? <line x1={0} y1={2} x2={0} y2={28} stroke={valueFill} strokeWidth="4px" /> : null}
                 <ToolTipText x={5} y={11} fontFamily={fontFamily} fontSize={fontSize}>
                     <ToolTipTSpanLabel fill={labelFill}>{yLabel}</ToolTipTSpanLabel>
                     <tspan x="5" dy="15" fill={valueFill}>{yValue}</tspan>
                 </ToolTipText>
-                </g>
-               )
+            </g>
+        )
     }
-    
+
     /**
      * Renders the value next to the label. 
      * The parent component must have a "text"-element.
      */
-    renderInline(){
+    renderInline() {
         const { yLabel, yValue, labelFill, valueFill, fontSize, fontFamily } = this.props;
-        
+
         return (
-                <tspan onClick={this.handleClick} fontFamily={fontFamily} fontSize={fontSize}>
-                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}:&nbsp;</ToolTipTSpanLabel>
-                    <tspan fill={valueFill}>{yValue} &nbsp;&nbsp;</tspan>
-                </tspan>
-               )
+            <tspan onClick={this.handleClick} fontFamily={fontFamily} fontSize={fontSize}>
+                <ToolTipTSpanLabel fill={labelFill}>{yLabel}:&nbsp;</ToolTipTSpanLabel>
+                <tspan fill={valueFill}>{yValue}&nbsp;&nbsp;</tspan>
+            </tspan>
+        )
     }
 
     render() {
-        
+
         const { layout } = this.props;
         let comp = null;
-        
-        switch (layout) {
+
+        switch ( layout ) {
             case "horizontal":
                 comp = this.renderValueNextToLabel();
                 break;
@@ -99,78 +99,78 @@ class SingleTooltip extends Component {
 }
 
 SingleTooltip.propTypes = {
-        origin: PropTypes.array.isRequired,
-        yLabel: PropTypes.string.isRequired,
-        yValue: PropTypes.string.isRequired,
-        onClick: PropTypes.func,
-        fontFamily: PropTypes.string,
-        labelFill: PropTypes.string.isRequired,
-        valueFill: PropTypes.string.isRequired,
-        fontSize: PropTypes.number,
-        withShape: PropTypes.bool,
-        forChart: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-        options: PropTypes.object.isRequired,
+    origin: PropTypes.array.isRequired,
+    yLabel: PropTypes.string.isRequired,
+    yValue: PropTypes.string.isRequired,
+    onClick: PropTypes.func,
+    fontFamily: PropTypes.string,
+    labelFill: PropTypes.string.isRequired,
+    valueFill: PropTypes.string.isRequired,
+    fontSize: PropTypes.number,
+    withShape: PropTypes.bool,
+    forChart: PropTypes.oneOfType( [PropTypes.number, PropTypes.string] ).isRequired,
+    options: PropTypes.object.isRequired,
 };
 
 SingleTooltip.defaultProps = {
-        labelFill: "#4682B4",
-        valueFill: "#000000",
-        withShape: false,
+    labelFill: "#4682B4",
+    valueFill: "#000000",
+    withShape: false,
 };
 
 class GroupTooltip extends Component {
-    constructor(props) {
-        super(props);
-        this.renderSVG = this.renderSVG.bind(this);
+    constructor( props ) {
+        super( props );
+        this.renderSVG = this.renderSVG.bind( this );
     }
-    renderSVG(moreProps) {
-        
+    renderSVG( moreProps ) {
+
         const { displayValuesFor } = this.props;
         const { chartId } = moreProps;
 
         const { className, onClick, width, verticalSize, fontFamily, fontSize, layout } = this.props;
         const { origin, displayFormat, options } = this.props;
-        const currentItem = displayValuesFor(this.props, moreProps);
-        
-        const singleTooltip = options.map((each, idx) => {
-                        
-                    const yValue = currentItem && each.yAccessor(currentItem);
-                    const yDisplayValue = yValue ? displayFormat(yValue) : "n/a";
+        const currentItem = displayValuesFor( this.props, moreProps );
 
-                    const orig = () => {
-                        if(layout == "horizontal" || layout == "horizontalRows"){
-                            return [width * idx, 0];
-                        }
-                        if(layout == "vertical"){
-                            return [0, verticalSize * idx];
-                        }
-                        if(layout == "verticalRows"){
-                            return [0, verticalSize * 2.3 * idx];
-                        }
-                        return [0, 0];
-                    }
+        const singleTooltip = options.map( ( each, idx ) => {
 
-                    return <SingleTooltip
-                            key={idx}
-                            layout={layout}
-                            origin={orig()} 
-                            yLabel={each.yLabel}
-                            yValue={yDisplayValue}
-                            options={each}
-                            forChart={chartId}
-                            onClick={onClick}
-                            fontFamily={fontFamily}
-                            fontSize={fontSize}
-                            labelFill={each.labelFill}
-                            valueFill={each.valueFill}
-                            withShape={each.withShape}
-                            />;
-                });
-        
+            const yValue = currentItem && each.yAccessor( currentItem );
+            const yDisplayValue = yValue ? displayFormat( yValue ) : "n/a";
+
+            const orig = () => {
+                if ( layout == "horizontal" || layout == "horizontalRows" ) {
+                    return [width * idx, 0];
+                }
+                if ( layout == "vertical" ) {
+                    return [0, verticalSize * idx];
+                }
+                if ( layout == "verticalRows" ) {
+                    return [0, verticalSize * 2.3 * idx];
+                }
+                return [0, 0];
+            }
+
+            return <SingleTooltip
+                key={idx}
+                layout={layout}
+                origin={orig()}
+                yLabel={each.yLabel}
+                yValue={yDisplayValue}
+                options={each}
+                forChart={chartId}
+                onClick={onClick}
+                fontFamily={fontFamily}
+                fontSize={fontSize}
+                labelFill={each.labelFill}
+                valueFill={each.valueFill}
+                withShape={each.withShape}
+            />;
+        } );
+
         return (
-            <g transform={`translate(${ origin[0] }, ${origin[1] })`} className={className}>
+            <g transform={`translate(${origin[0]}, ${origin[1]})`} className={className}>
                 {layout == "horizontalInline"
-                    ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText> 
+                    ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText>
                     : singleTooltip
                 }
             </g>
@@ -187,12 +187,20 @@ class GroupTooltip extends Component {
 
 GroupTooltip.propTypes = {
     className: PropTypes.string,
-    layout: PropTypes.oneOf([
-        "horizontal", 
-        "horizontalRows", 
-        "horizontalInline", 
-        "vertical", 
-        "verticalRows"]).isRequired,
+    layout: PropTypes.oneOf( [
+        "horizontal",
+        "horizontalRows",
+        "horizontalInline",
+        "vertical",
+        "verticalRows"] ).isRequired,
+    // TODO: please implement this
+    position: PropTypes.oneOf( [
+        "topLeft",
+        "topRight",
+        "topCenter",
+        "bottomLeft",
+        "bottomRight",
+        "bottomCenter"] ).isRequired,
     displayFormat: PropTypes.func.isRequired,
     origin: PropTypes.array.isRequired,
     displayValuesFor: PropTypes.func,
@@ -201,24 +209,25 @@ GroupTooltip.propTypes = {
     fontSize: PropTypes.number,
     width: PropTypes.number, // "width" only be used, if layout is "horizontal" or "horizontalRows".
     verticalSize: PropTypes.number,  // "verticalSize" only be used, if layout is "vertical", "verticalRows".
-    options: PropTypes.arrayOf(PropTypes.shape({
-        yLabel: PropTypes.oneOfType([
-                PropTypes.string,
-                PropTypes.func]).isRequired,
+    options: PropTypes.arrayOf( PropTypes.shape( {
+        yLabel: PropTypes.oneOfType( [
+            PropTypes.string,
+            PropTypes.func] ).isRequired,
         yAccessor: PropTypes.func.isRequired,
         labelFill: PropTypes.string,
         valueFill: PropTypes.string,
         withShape: PropTypes.bool, // "withShape" is ignored, if layout is "horizontalInline" or "vertical".
-    })),
+    } ) ),
 };
 
 GroupTooltip.defaultProps = {
     className: "react-stockcharts-tooltip react-stockcharts-group-tooltip",
     layout: "horizontal",
-    displayFormat: format(".2f"),
+    position: "topLeft",
+    displayFormat: format( ".2f" ),
     displayValuesFor: displayValuesFor,
     origin: [0, 0],
-    width: 60, 
+    width: 60,
     verticalSize: 13,
 };
 

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -123,6 +123,41 @@ class GroupTooltip extends Component {
         super( props );
         this.renderSVG = this.renderSVG.bind( this );
     }
+    
+    // TODO: please implement this
+    // the retuned x-y-array must have the right x and y
+    // for the translate-property of the groupTooltip-component.
+    getPosition(props) {
+        const { position } = this.props;
+        let xyPos = [];
+
+        switch ( layout ) {
+            case "topLeft":
+                xyPos = [0, 0];
+                break;
+            case "topRight":
+                xyPos = [0, 0];
+                break;
+            case "topCenter":
+                xyPos = [0, 0];
+                break;
+            case "bottomLeft":
+                xyPos = [0, 0];
+                break;
+            case "bottomRight":
+                xyPos = [0, 0];
+                break;
+            case "bottomCenter":
+                xyPos = [0, 0];
+                break;
+            default:
+                xyPos = [0, 0];
+        }
+
+        return xyPos;
+    }
+    
+    
     renderSVG( moreProps ) {
 
         const { displayValuesFor } = this.props;
@@ -131,6 +166,8 @@ class GroupTooltip extends Component {
         const { className, onClick, width, verticalSize, fontFamily, fontSize, layout } = this.props;
         const { origin, displayFormat, options } = this.props;
         const currentItem = displayValuesFor( this.props, moreProps );
+        // TODO: implement this.getPosition(props)
+        const xyPos = this.getPosition(props);
 
         const singleTooltip = options.map( ( each, idx ) => {
 
@@ -168,6 +205,7 @@ class GroupTooltip extends Component {
         } );
 
         return (
+            // TODO: use xyPos-array for transform-property
             <g transform={`translate(${origin[0]}, ${origin[1]})`} className={className}>
                 {layout == "horizontalInline"
                     ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText>
@@ -193,7 +231,6 @@ GroupTooltip.propTypes = {
         "horizontalInline",
         "vertical",
         "verticalRows"] ).isRequired,
-    // TODO: please implement this
     position: PropTypes.oneOf( [
         "topLeft",
         "topRight",

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -127,11 +127,11 @@ class GroupTooltip extends Component {
     // TODO: please implement this
     // the retuned x-y-array must have the right x and y
     // for the translate-property of the groupTooltip-component.
-    getPosition(props) {
+    getPosition() {
         const { position } = this.props;
         let xyPos = [];
 
-        switch ( layout ) {
+        switch ( position ) {
             case "topLeft":
                 xyPos = [0, 0];
                 break;
@@ -167,7 +167,7 @@ class GroupTooltip extends Component {
         const { origin, displayFormat, options } = this.props;
         const currentItem = displayValuesFor( this.props, moreProps );
         // TODO: implement this.getPosition(props)
-        const xyPos = this.getPosition(props);
+        const xyPos = this.getPosition();
 
         const singleTooltip = options.map( ( each, idx ) => {
 
@@ -231,6 +231,7 @@ GroupTooltip.propTypes = {
         "horizontalInline",
         "vertical",
         "verticalRows"] ).isRequired,
+    // TODO: please implement this
     position: PropTypes.oneOf( [
         "topLeft",
         "topRight",


### PR DESCRIPTION
**With "GroupTooltip" (="MultipleValueTooltip"), different tooltip layouts can be selected:**

- **Horizontal-Layout** has fixed width of label-value-pair (the same as when using SingleValueTooltip or MovingAverageTooltip):
![layouthorizontal](https://user-images.githubusercontent.com/3045549/34492109-7357c5f0-efe6-11e7-8539-10b837821c57.png)

- **HorizontalRows-Layout** has fixed width of label-value-pair where each value is rendered below its label (the same as when MovingAverageTooltip):
![layouthorizontalrows](https://user-images.githubusercontent.com/3045549/34492181-bbc28c08-efe6-11e7-94fa-b1ce13d3630b.png)


- **HorizontalInline-Layout** has variable width of label-value-pair. Actually, when using a pair of SingleValueTooltip or MovingAverageTooltip, labels can be cut if given width is too short. With "HorizontalInline" , no need to set width, because it s displayed inline and labels are not cut:
![layouthorizontalinline](https://user-images.githubusercontent.com/3045549/34492259-19538db8-efe7-11e7-9f7a-3aba023b50bc.png)


- **Vertical-Layout** renders label-value-pair vertically:
![layoutvertical](https://user-images.githubusercontent.com/3045549/34492385-9ff2cff0-efe7-11e7-9dcb-c3736f1a04ef.png)

- **VerticalRows-Layout** renders label-value-pair vertically with rows (same as MovingAverageTooltip, but renders vertically):
![layoutverticalrows](https://user-images.githubusercontent.com/3045549/34492426-d0eea98a-efe7-11e7-9f99-8a94ea64f913.png)

**Notes:**
- The shapes on the left hand side of the label-value-pair can be disabled by "withShape=false".
- With "GroupTooltip.js", "MovingAverageTooltip.js" can be **removed** from the repo because "GroupTooltip" with layout="horizontalRows" and "withShape=true" renders exactly the same as when using MovingAverageTooltip.
- Maybe you can extend the actual "SingleValueTooltip.js" and use "SingleValueTooltip" instead of "SingleTooltip" (which is actually a class within the "GroupTooltip.js) for GroupTooltip. So "SingleValueTooltip.js" can be the new "SingleTooltip.js" which then can be used by GroupTooltip. I have created "SingleTooltip", because with the actual "SingleValueTooltip" it is not possible to render "label/value"-pairs **_inline_** (because of its GenericComponent which renders a "g" before a text-element). (Maybe you can extend "SingleValueTooltip" to have the capabilities of the actual "SingleTooltip". Rename it to "SingleTooltip". Remove "SingleTooltip"-class from "GroupTooltip" and use the new "SingleTooltip" within "GroupTooltip".)
- "GroupTooltip.js" can be a substitution for all other tooltips (e.g. MovingAverageTooltip/...). So the other tooltips with same results can be removed.


Please review and improve code. Thanks!







