### PR TITLE
BarAnnotation

### DIFF
--- a/src/lib/annotation/BarAnnotation.js
+++ b/src/lib/annotation/BarAnnotation.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { functor } from "../utils";
 
-class TickAnnotation extends Component {
+class BarAnnotation extends Component {
 	constructor(props) {
 		super(props);
 		this.handleClick = this.handleClick.bind(this);
@@ -87,7 +87,7 @@ function getArrowForTextIcon(type) {
     return arrows[type];
 }
 
-TickAnnotation.propTypes = {
+BarAnnotation.propTypes = {
 	className: PropTypes.string,
 	path: PropTypes.func,
 	onClick: PropTypes.func,
@@ -117,8 +117,8 @@ TickAnnotation.propTypes = {
     textIconAnchor: PropTypes.string,
 };
 
-TickAnnotation.defaultProps = {
-	className: "react-stockcharts-TickAnnotation",
+BarAnnotation.defaultProps = {
+	className: "react-stockcharts-BarAnnotation",
 	opacity: 1,
 	fill: "#000",
 	textAnchor: "middle",
@@ -131,4 +131,4 @@ TickAnnotation.defaultProps = {
 	x: ({ xScale, xAccessor, datum }) => xScale(xAccessor(datum)),
 };
 
-export default TickAnnotation;
+export default BarAnnotation;

--- a/src/lib/annotation/TickAnnotation.js
+++ b/src/lib/annotation/TickAnnotation.js
@@ -1,0 +1,134 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { functor } from "../utils";
+
+class TickAnnotation extends Component {
+	constructor(props) {
+		super(props);
+		this.handleClick = this.handleClick.bind(this);
+	}
+	handleClick(e) {
+		const { onClick } = this.props;
+
+		if (onClick) {
+			const { xScale, yScale, datum } = this.props;
+			onClick({ xScale, yScale, datum }, e);
+		}
+	}
+	render() {
+		const { className, stroke, opacity } = this.props;
+		const { xAccessor, xScale, yScale, path } = this.props;
+		const { text, textXOffset, textYOffset, textAnchor, fontFamily, fontSize, textFill, textOpacity, textRotate } = this.props;
+		const { x, y, fill, tooltip } = helper(this.props, xAccessor, xScale, yScale);
+		const {textIcon, textIconFontSize, textIconFill, textIconOpacity, textIconRotate, textIconXOffset, textIconYOffset} = this.props;
+
+		return (<g className={className} onClick={this.handleClick}>
+		        {tooltip != undefined ? <title>{tooltip}</title> : null}
+                {text != undefined ? <text 
+                        x={x} 
+                        y={y} 
+                        dx={textXOffset} 
+                        dy={textYOffset} 
+                        fontFamily={fontFamily} 
+                        fontSize={fontSize}
+                        fill={textFill} 
+                        opacity={textOpacity}
+                        transform={textRotate != undefined ? `rotate(${textRotate}, ${x}, ${y})` : null}
+                        textAnchor={textAnchor}>{text}</text> : null}
+                  {textIcon != undefined ? <text 
+                        x={x} 
+                        y={y} 
+                        dx={textIconXOffset}
+                        dy={textIconYOffset} 
+                        fontSize={textIconFontSize}
+                        fill={textIconFill}
+                        opacity={textIconOpacity}
+                        transform={textIconRotate !=undefined ? `rotate(${textIconRotate}, ${x}, ${y})`: null}
+                        textAnchor={textAnchor}>{textIcon}</text> : null}
+                  {path != undefined ? <path d={path({ x, y })} stroke={stroke} fill={fill} opacity={opacity} /> : null}
+		        </g>);
+	}
+}
+
+function helper(props, xAccessor, xScale, yScale) {
+	const { x, y, datum, fill, tooltip, plotData } = props;
+
+	const xFunc = functor(x);
+	const yFunc = functor(y);
+
+	const [xPos, yPos] = [xFunc({ xScale, xAccessor, datum, plotData }), yFunc({ yScale, datum, plotData })];
+
+	return {
+		x: xPos,
+		y: yPos,
+		fill: functor(fill)(datum),
+		tooltip: functor(tooltip)(datum),
+	};
+}
+
+/**
+ * any unicode can be applied.
+ * @param {any} type
+ */
+function getArrowForTextIcon(type) {
+    const arrows = {
+            simpleUp: "⬆",
+            simpleDown: "⬇",
+            fatUp: "▲",
+            fatDown: "▼",
+            lightUp: "↑",
+            lightDown: "↓",
+            dashedUp: "⇡",
+            dashedDown: "⇣",
+            dashedRight: "➟",
+            fatRight: "➡",
+            right: "➤",
+    }
+    return arrows[type];
+}
+
+TickAnnotation.propTypes = {
+	className: PropTypes.string,
+	path: PropTypes.func,
+	onClick: PropTypes.func,
+	xAccessor: PropTypes.func,
+	xScale: PropTypes.func,
+	yScale: PropTypes.func,
+	datum: PropTypes.object,
+	stroke: PropTypes.string,
+	fill: PropTypes.string,
+	opacity: PropTypes.number,
+	text: PropTypes.string,
+    textAnchor: PropTypes.string,
+    fontFamily: PropTypes.string,
+    fontSize: PropTypes.number,
+    textOpacity: PropTypes.number,
+    textFill: PropTypes.string,
+    textRotate: PropTypes.number,
+    textXOffset: PropTypes.number,
+    textYOffset: PropTypes.number,
+    textIcon: PropTypes.string,
+    textIconFontSize: PropTypes.number,
+    textIconOpacity: PropTypes.number,
+    textIconFill: PropTypes.string,
+    textIconRotate: PropTypes.number,
+    textIconXOffset: PropTypes.number,
+    textIconYOffset: PropTypes.number,
+    textIconAnchor: PropTypes.string,
+};
+
+TickAnnotation.defaultProps = {
+	className: "react-stockcharts-TickAnnotation",
+	opacity: 1,
+	fill: "#000",
+	textAnchor: "middle",
+    fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
+    fontSize: 10,
+    textFill: "#000",
+    textOpacity: 1,
+    textIconFill: "#000",
+    textIconFontSize: 10,
+	x: ({ xScale, xAccessor, datum }) => xScale(xAccessor(datum)),
+};
+
+export default TickAnnotation;

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -1,0 +1,225 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { format } from "d3-format";
+import displayValuesFor from "./displayValuesFor";
+import GenericChartComponent from "../GenericChartComponent";
+import ToolTipText from "./ToolTipText";
+import ToolTipTSpanLabel from "./ToolTipTSpanLabel";
+
+import { functor } from "../utils";
+
+class SingleTooltip extends Component {
+    
+    constructor(props) {
+        super(props);
+        this.handleClick = this.handleClick.bind(this);
+    }
+    
+    handleClick(e) {
+        const { onClick, forChart, options } = this.props;
+        onClick({ chartId: forChart, ...options }, e);
+    }
+    
+    /**
+     * Renders the value next to the label.
+     */
+    renderValueNextToLabel(){
+        const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
+
+        return (
+                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
+                {withShape ? <rect x="0" y="-6" width="6" height="6" fill={valueFill} /> : null}
+                <ToolTipText x={withShape ? 8 : 0} y={0} fontFamily={fontFamily} fontSize={fontSize}>
+                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}: </ToolTipTSpanLabel>
+                    <tspan fill={valueFill}>{yValue}</tspan>
+                </ToolTipText>
+                </g>
+               )
+    }
+    
+    /**
+     * Renders the value beneath the label.
+     */
+    renderValueBeneathToLabel(){
+        const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
+
+        return (
+                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
+                {withShape ? <line x1={0} y1={2} x2={0} y2={28} stroke={valueFill} strokeWidth="4px"/> : null}
+                <ToolTipText x={5} y={11} fontFamily={fontFamily} fontSize={fontSize}>
+                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}</ToolTipTSpanLabel>
+                    <tspan x="5" dy="15" fill={valueFill}>{yValue}</tspan>
+                </ToolTipText>
+                </g>
+               )
+    }
+    
+    /**
+     * Renders the value next to the label. 
+     * The parent component must have a "text"-element.
+     */
+    renderInline(){
+        const { yLabel, yValue, labelFill, valueFill, fontSize, fontFamily } = this.props;
+        
+        return (
+                <tspan onClick={this.handleClick} fontFamily={fontFamily} fontSize={fontSize}>
+                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}:&nbsp;</ToolTipTSpanLabel>
+                    <tspan fill={valueFill}>{yValue} &nbsp;&nbsp;</tspan>
+                </tspan>
+               )
+    }
+
+    render() {
+        
+        const { layout } = this.props;
+        let comp = null;
+        
+        switch (layout) {
+            case "horizontal":
+                comp = this.renderValueNextToLabel();
+                break;
+            case "horizontalRows":
+                comp = this.renderValueBeneathToLabel();
+                break;
+            case "horizontalInline":
+                comp = this.renderInline();
+                break;
+            case "vertical":
+                comp = this.renderValueNextToLabel();
+                break;
+            case "verticalRows":
+                comp = this.renderValueBeneathToLabel();
+                break;
+            default:
+                comp = this.renderValueNextToLabel();
+        }
+
+        return comp;
+    }
+}
+
+SingleTooltip.propTypes = {
+        origin: PropTypes.array.isRequired,
+        yLabel: PropTypes.string.isRequired,
+        yValue: PropTypes.string.isRequired,
+        onClick: PropTypes.func,
+        fontFamily: PropTypes.string,
+        labelFill: PropTypes.string.isRequired,
+        valueFill: PropTypes.string.isRequired,
+        fontSize: PropTypes.number,
+        withShape: PropTypes.bool,
+        forChart: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+        options: PropTypes.object.isRequired,
+};
+
+SingleTooltip.defaultProps = {
+        labelFill: "#4682B4",
+        valueFill: "#000000",
+        withShape: false,
+};
+
+class GroupTooltip extends Component {
+    constructor(props) {
+        super(props);
+        this.renderSVG = this.renderSVG.bind(this);
+    }
+    renderSVG(moreProps) {
+        
+        const { displayValuesFor } = this.props;
+        const { chartId } = moreProps;
+
+        const { className, onClick, width, verticalSize, fontFamily, fontSize, layout } = this.props;
+        const { origin, displayFormat, options } = this.props;
+        const currentItem = displayValuesFor(this.props, moreProps);
+        
+        const singleTooltip = options.map((each, idx) => {
+                        
+                    const yValue = currentItem && each.yAccessor(currentItem);
+                    const yDisplayValue = yValue ? displayFormat(yValue) : "n/a";
+
+                    const orig = () => {
+                        if(layout == "horizontal" || layout == "horizontalRows"){
+                            return [width * idx, 0];
+                        }
+                        if(layout == "vertical"){
+                            return [0, verticalSize * idx];
+                        }
+                        if(layout == "verticalRows"){
+                            return [0, verticalSize * 2.3 * idx];
+                        }
+                        return [0, 0];
+                    }
+
+                    return <SingleTooltip
+                            key={idx}
+                            layout={layout}
+                            origin={orig()} 
+                            yLabel={each.yLabel}
+                            yValue={yDisplayValue}
+                            options={each}
+                            forChart={chartId}
+                            onClick={onClick}
+                            fontFamily={fontFamily}
+                            fontSize={fontSize}
+                            labelFill={each.labelFill}
+                            valueFill={each.valueFill}
+                            withShape={each.withShape}
+                            />;
+                });
+        
+        return (
+            <g transform={`translate(${ origin[0] }, ${origin[1] })`} className={className}>
+                {layout == "horizontalInline"
+                    ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText> 
+                    : singleTooltip
+                }
+            </g>
+        );
+    }
+    render() {
+        return <GenericChartComponent
+            clip={false}
+            svgDraw={this.renderSVG}
+            drawOn={["mousemove"]}
+        />;
+    }
+}
+
+GroupTooltip.propTypes = {
+    className: PropTypes.string,
+    layout: PropTypes.oneOf([
+        "horizontal", 
+        "horizontalRows", 
+        "horizontalInline", 
+        "vertical", 
+        "verticalRows"]).isRequired,
+    displayFormat: PropTypes.func.isRequired,
+    origin: PropTypes.array.isRequired,
+    displayValuesFor: PropTypes.func,
+    onClick: PropTypes.func,
+    fontFamily: PropTypes.string,
+    fontSize: PropTypes.number,
+    width: PropTypes.number, // "width" only be used, if layout is "horizontal" or "horizontalRows".
+    verticalSize: PropTypes.number,  // "verticalSize" only be used, if layout is "vertical", "verticalRows".
+    options: PropTypes.arrayOf(PropTypes.shape({
+        yLabel: PropTypes.oneOfType([
+                PropTypes.string,
+                PropTypes.func]).isRequired,
+        yAccessor: PropTypes.func.isRequired,
+        labelFill: PropTypes.string,
+        valueFill: PropTypes.string,
+        withShape: PropTypes.bool, // "withShape" is ignored, if layout is "horizontalInline" or "vertical".
+    })),
+};
+
+GroupTooltip.defaultProps = {
+    className: "react-stockcharts-tooltip react-stockcharts-group-tooltip",
+    layout: "horizontal",
+    displayFormat: format(".2f"),
+    displayValuesFor: displayValuesFor,
+    origin: [0, 0],
+    width: 60, 
+    verticalSize: 13,
+};
+
+export default GroupTooltip;


### PR DESCRIPTION
"BarAnnotation.js" allows the creation of any kind of annotation. A pair of "text", "textIcon", "tooltip", "shape" where each item can be positioned and styled. Each item is optional. The shape can also be replaced by a "textIcon" (uses common unicodes).

**For example (pure text without shape, uses tooltip+textIcon+text):**

![tickannotation](https://user-images.githubusercontent.com/3045549/34544049-575209fc-f0e4-11e7-8864-cce960d4c613.png)

Everything can be styled and positioned individually.

With "BarAnnotation.js", the "LabelAnnotation.js" and the "SvgPathAnnotation.js" can be removed from the repo, because with "BarAnnotation.js" labels, and svgPath can also be made and also in pair. For example, different strategies can be rendered with same shapes but different labels. 


  