### PR TITLE
Cursor.js

### DIFF
--- a/src/lib/coordinates/Cursor.js
+++ b/src/lib/coordinates/Cursor.js
@@ -15,7 +15,7 @@ class Cursor extends Component {
 	getXYCursor(props, moreProps) {
 
 	    const { mouseXY, currentItem, show, height, width } = moreProps;
-	    const { customX, stroke, opacity, strokeDasharray, disableYCursor } = props;
+	    const { customSnapX, stroke, opacity, strokeDasharray, disableYCursor } = props;
 	    if (!show || isNotDefined(currentItem)) return null;
 	    
 	    const yCursor = {
@@ -26,7 +26,7 @@ class Cursor extends Component {
 	        stroke, strokeDasharray, opacity,
 	        id: "yCursor"
 	    };
-	    const x = customX(props, moreProps);
+	    const x = customSnapX(props, moreProps);
 
 	    const xCursor = {
 	        x1: x,
@@ -190,7 +190,7 @@ Cursor.contextTypes = {
 	// xScale: PropTypes.func.isRequired,
 };
 
-function customX(props, moreProps) {
+function customSnapX(props, moreProps) {
 	const { xScale, xAccessor, currentItem, mouseXY } = moreProps;
 	const { snapX } = props;
 	const x = snapX
@@ -203,8 +203,8 @@ Cursor.defaultProps = {
 	stroke: "#000000",
 	opacity: 0.3,
 	strokeDasharray: "ShortDash",
-	snapX: true,
-	customX,
+	snapX: true, // snaps the crosshair to the nearest xValue
+	customSnapX,
 	disableYCursor: false,
 	useXCursorShape: false,
 	xCursorShapeStroke: "#000000",

--- a/src/lib/coordinates/Cursor.js
+++ b/src/lib/coordinates/Cursor.js
@@ -1,0 +1,200 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import GenericComponent, { getMouseCanvas } from "../GenericComponent";
+
+import { first, last, hexToRGBA, isDefined, isNotDefined, strokeDashTypes, getStrokeDasharray } from "../utils";
+
+class Cursor extends Component {
+    
+	constructor(props) {
+		super(props);
+		this.renderSVG = this.renderSVG.bind(this);
+		this.drawOnCanvas = this.drawOnCanvas.bind(this);
+	}
+	
+    getXCursorShape(props, moreProps, ctx) {
+
+        const { height, xScale, currentItem, plotData } = moreProps;
+        const { xAccessor } = moreProps;
+        const xValue = xAccessor(currentItem);
+        const centerX = xScale(xValue);
+        const shapeWidth = Math.abs(xScale(xAccessor(last(plotData))) - xScale(xAccessor(first(plotData)))) / (plotData.length - 1);
+        const xPos = centerX - shapeWidth / 2;
+        
+        return { height, xPos, shapeWidth };
+    }	
+	
+	drawOnCanvas(ctx, moreProps) {
+	    
+		const cursors = getXYCursor(this.props, moreProps);
+
+		if (isDefined(cursors)) {
+
+		    const { useXCursorShape } = this.props;
+		    
+			const { margin, ratio } = this.context;
+			const originX = 0.5 * ratio + margin.left;
+			const originY = 0.5 * ratio + margin.top;
+
+			ctx.save();
+			ctx.setTransform(1, 0, 0, 1, 0, 0);
+			ctx.scale(ratio, ratio);
+
+			ctx.translate(originX, originY);
+
+			cursors.forEach(line => {
+				const dashArray = getStrokeDasharray(line.strokeDasharray).split(",").map(d => +d);
+				
+				if( useXCursorShape && line.id == "xCursor" ) {
+                    const { xCursorShapeFill, xCursorShapeOpacity, xCursorShapeStroke, xCursorShapeStrokeDasharray } = this.props;
+                    const xShape = this.getXCursorShape(this.props, moreProps);
+
+                    if(xCursorShapeStrokeDasharray != undefined) {
+                        ctx.strokeStyle = hexToRGBA(xCursorShapeStroke, xCursorShapeOpacity);
+                        ctx.setLineDash(getStrokeDasharray(xCursorShapeStrokeDasharray).split(",").map(d => +d));
+                    }
+
+                    ctx.beginPath();
+                    ctx.fillStyle = hexToRGBA(xCursorShapeFill, xCursorShapeOpacity);
+                    ctx.beginPath();
+                    xCursorShapeStrokeDasharray == undefined ? 
+                            ctx.fillRect(xShape.xPos, 0, xShape.shapeWidth, xShape.height) : 
+                            ctx.rect(xShape.xPos, 0, xShape.shapeWidth, xShape.height);
+                    ctx.fill();
+				}
+				else{
+				    ctx.strokeStyle = hexToRGBA(line.stroke, line.opacity);
+	                ctx.setLineDash(dashArray);
+	                ctx.beginPath();
+				    ctx.moveTo(line.x1, line.y1);
+	                ctx.lineTo(line.x2, line.y2);
+				}
+
+				ctx.stroke();
+			});
+
+			ctx.restore();
+		}
+	}
+	
+	renderSVG(moreProps) {
+
+		const cursors = getXYCursor(this.props, moreProps);
+		if (isNotDefined(cursors)) return null;
+		
+		const { className, useXCursorShape } = this.props;
+
+		return (
+			<g className={`react-stockcharts-crosshair ${className}`}>
+				{cursors.map(({ strokeDasharray, id, ...rest }, idx) => {
+				    
+				    if( useXCursorShape && id == "xCursor" ) {
+				        const { xCursorShapeFill, xCursorShapeOpacity, xCursorShapeStroke, xCursorShapeStrokeDasharray } = this.props;
+				        const xShape = this.getXCursorShape(this.props, moreProps);
+				        return  <rect  
+        				         key={idx} 
+				             x={xShape.xPos} 
+				             y={0} 
+				             width={xShape.shapeWidth} 
+				             height={xShape.height} 
+				             fill={xCursorShapeFill} 
+				             stroke={xCursorShapeStrokeDasharray == undefined ? null : xCursorShapeStroke} 
+				             strokeDasharray={xCursorShapeStrokeDasharray == undefined ? null : getStrokeDasharray(xCursorShapeStrokeDasharray)} 
+				             opacity={xCursorShapeOpacity} /> 
+				    }
+				    
+				    return <line 
+				         key={idx}
+				         strokeDasharray={getStrokeDasharray(strokeDasharray)}
+				         {...rest} />
+				})}
+			</g>
+		);
+	}
+	
+	render() {
+		return <GenericComponent
+			svgDraw={this.renderSVG}
+			clip={false}
+			canvasDraw={this.drawOnCanvas}
+			canvasToDraw={getMouseCanvas}
+			drawOn={["mousemove", "pan", "drag"]}
+		/>;
+	}
+}
+
+Cursor.propTypes = {
+    className: PropTypes.string,
+    stroke: PropTypes.string,
+	strokeDasharray: PropTypes.oneOf(strokeDashTypes),
+	snapX: PropTypes.bool,
+	opacity: PropTypes.number,
+	disableYCursor: PropTypes.bool,
+	useXCursorShape: PropTypes.bool,
+	xCursorShapeFill: PropTypes.string,
+	xCursorShapeStroke: PropTypes.string,
+	xCursorShapeStrokeDasharray: PropTypes.oneOf(strokeDashTypes),
+	xCursorShapeOpacity: PropTypes.number,
+};
+
+Cursor.contextTypes = {
+	margin: PropTypes.object.isRequired,
+	ratio: PropTypes.number.isRequired,
+	// xScale for getting update event upon pan end, this is needed to get past the PureComponent shouldComponentUpdate
+	// xScale: PropTypes.func.isRequired,
+};
+
+function customX(props, moreProps) {
+	const { xScale, xAccessor, currentItem, mouseXY } = moreProps;
+	const { snapX } = props;
+	const x = snapX
+		? Math.round(xScale(xAccessor(currentItem)))
+		: mouseXY[0];
+	return x;
+}
+
+Cursor.defaultProps = {
+	stroke: "#000000",
+	opacity: 0.3,
+	strokeDasharray: "ShortDash",
+	snapX: true,
+	customX,
+	disableYCursor: false,
+	useXCursorShape: false,
+	xCursorShapeStroke: "#000000",
+	xCursorShapeFill: "#D4E2FD",
+	xCursorShapeOpacity: 0.5,
+};
+
+function getXYCursor(props, moreProps) {
+
+	const {
+		mouseXY, currentItem, show, height, width
+	} = moreProps;
+
+	const { customX, stroke, opacity, strokeDasharray, disableYCursor } = props;
+
+	if (!show || isNotDefined(currentItem)) return null;
+	
+	const yCursor = {
+		x1: 0,
+		x2: width,
+		y1: mouseXY[1],
+		y2: mouseXY[1],
+		stroke, strokeDasharray, opacity,
+		id: "yCursor"
+	};
+	const x = customX(props, moreProps);
+
+	const xCursor = {
+		x1: x,
+		x2: x,
+		y1: 0,
+		y2: height,
+		stroke, strokeDasharray, opacity,
+		id: "xCursor"
+	};
+	return disableYCursor ? [xCursor] : [yCursor, xCursor];
+}
+
+export default Cursor;

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -1,0 +1,225 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { format } from "d3-format";
+import displayValuesFor from "./displayValuesFor";
+import GenericChartComponent from "../GenericChartComponent";
+import ToolTipText from "./ToolTipText";
+import ToolTipTSpanLabel from "./ToolTipTSpanLabel";
+
+import { functor } from "../utils";
+
+class SingleTooltip extends Component {
+    
+    constructor(props) {
+        super(props);
+        this.handleClick = this.handleClick.bind(this);
+    }
+    
+    handleClick(e) {
+        const { onClick, forChart, options } = this.props;
+        onClick({ chartId: forChart, ...options }, e);
+    }
+    
+    /**
+     * Renders the value next to the label.
+     */
+    renderValueNextToLabel(){
+        const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
+
+        return (
+                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
+                {withShape ? <rect x="0" y="-6" width="6" height="6" fill={valueFill} /> : null}
+                <ToolTipText x={withShape ? 8 : 0} y={0} fontFamily={fontFamily} fontSize={fontSize}>
+                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}: </ToolTipTSpanLabel>
+                    <tspan fill={valueFill}>{yValue}</tspan>
+                </ToolTipText>
+                </g>
+               )
+    }
+    
+    /**
+     * Renders the value beneath the label.
+     */
+    renderValueBeneathToLabel(){
+        const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
+
+        return (
+                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
+                {withShape ? <line x1={0} y1={2} x2={0} y2={28} stroke={valueFill} strokeWidth="4px"/> : null}
+                <ToolTipText x={5} y={11} fontFamily={fontFamily} fontSize={fontSize}>
+                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}</ToolTipTSpanLabel>
+                    <tspan x="5" dy="15" fill={valueFill}>{yValue}</tspan>
+                </ToolTipText>
+                </g>
+               )
+    }
+    
+    /**
+     * Renders the value next to the label. 
+     * The parent component must have a "text"-element.
+     */
+    renderInline(){
+        const { yLabel, yValue, labelFill, valueFill, fontSize, fontFamily } = this.props;
+        
+        return (
+                <tspan onClick={this.handleClick} fontFamily={fontFamily} fontSize={fontSize}>
+                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}:&nbsp;</ToolTipTSpanLabel>
+                    <tspan fill={valueFill}>{yValue} &nbsp;&nbsp;</tspan>
+                </tspan>
+               )
+    }
+
+    render() {
+        
+        const { layout } = this.props;
+        let comp = null;
+        
+        switch (layout) {
+            case "horizontal":
+                comp = this.renderValueNextToLabel();
+                break;
+            case "horizontalRows":
+                comp = this.renderValueBeneathToLabel();
+                break;
+            case "horizontalInline":
+                comp = this.renderInline();
+                break;
+            case "vertical":
+                comp = this.renderValueNextToLabel();
+                break;
+            case "verticalRows":
+                comp = this.renderValueBeneathToLabel();
+                break;
+            default:
+                comp = this.renderValueNextToLabel();
+        }
+
+        return comp;
+    }
+}
+
+SingleTooltip.propTypes = {
+        origin: PropTypes.array.isRequired,
+        yLabel: PropTypes.string.isRequired,
+        yValue: PropTypes.string.isRequired,
+        onClick: PropTypes.func,
+        fontFamily: PropTypes.string,
+        labelFill: PropTypes.string.isRequired,
+        valueFill: PropTypes.string.isRequired,
+        fontSize: PropTypes.number,
+        withShape: PropTypes.bool,
+        forChart: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+        options: PropTypes.object.isRequired,
+};
+
+SingleTooltip.defaultProps = {
+        labelFill: "#4682B4",
+        valueFill: "#000000",
+        withShape: false,
+};
+
+class GroupTooltip extends Component {
+    constructor(props) {
+        super(props);
+        this.renderSVG = this.renderSVG.bind(this);
+    }
+    renderSVG(moreProps) {
+        
+        const { displayValuesFor } = this.props;
+        const { chartId } = moreProps;
+
+        const { className, onClick, width, verticalSize, fontFamily, fontSize, layout } = this.props;
+        const { origin, displayFormat, options } = this.props;
+        const currentItem = displayValuesFor(this.props, moreProps);
+        
+        const singleTooltip = options.map((each, idx) => {
+                        
+                    const yValue = currentItem && each.yAccessor(currentItem);
+                    const yDisplayValue = yValue ? displayFormat(yValue) : "n/a";
+
+                    const orig = () => {
+                        if(layout == "horizontal" || layout == "horizontalRows"){
+                            return [width * idx, 0];
+                        }
+                        if(layout == "vertical"){
+                            return [0, verticalSize * idx];
+                        }
+                        if(layout == "verticalRows"){
+                            return [0, verticalSize * 2.3 * idx];
+                        }
+                        return [0, 0];
+                    }
+
+                    return <SingleTooltip
+                            key={idx}
+                            layout={layout}
+                            origin={orig()} 
+                            yLabel={each.yLabel}
+                            yValue={yDisplayValue}
+                            options={each}
+                            forChart={chartId}
+                            onClick={onClick}
+                            fontFamily={fontFamily}
+                            fontSize={fontSize}
+                            labelFill={each.labelFill}
+                            valueFill={each.valueFill}
+                            withShape={each.withShape}
+                            />;
+                });
+        
+        return (
+            <g transform={`translate(${ origin[0] }, ${origin[1] })`} className={className}>
+                {layout == "horizontalInline"
+                    ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText> 
+                    : singleTooltip
+                }
+            </g>
+        );
+    }
+    render() {
+        return <GenericChartComponent
+            clip={false}
+            svgDraw={this.renderSVG}
+            drawOn={["mousemove"]}
+        />;
+    }
+}
+
+GroupTooltip.propTypes = {
+    className: PropTypes.string,
+    layout: PropTypes.oneOf([
+        "horizontal", 
+        "horizontalRows", 
+        "horizontalInline", 
+        "vertical", 
+        "verticalRows"]).isRequired,
+    displayFormat: PropTypes.func.isRequired,
+    origin: PropTypes.array.isRequired,
+    displayValuesFor: PropTypes.func,
+    onClick: PropTypes.func,
+    fontFamily: PropTypes.string,
+    fontSize: PropTypes.number,
+    width: PropTypes.number, // "width" only be used, if layout is "horizontal" or "horizontalRows".
+    verticalSize: PropTypes.number,  // "verticalSize" only be used, if layout is "vertical", "verticalRows".
+    options: PropTypes.arrayOf(PropTypes.shape({
+        yLabel: PropTypes.oneOfType([
+                PropTypes.string,
+                PropTypes.func]).isRequired,
+        yAccessor: PropTypes.func.isRequired,
+        labelFill: PropTypes.string,
+        valueFill: PropTypes.string,
+        withShape: PropTypes.bool, // "withShape" is ignored, if layout is "horizontalInline" or "vertical".
+    })),
+};
+
+GroupTooltip.defaultProps = {
+    className: "react-stockcharts-tooltip react-stockcharts-group-tooltip",
+    layout: "horizontal",
+    displayFormat: format(".2f"),
+    displayValuesFor: displayValuesFor,
+    origin: [0, 0],
+    width: 60, 
+    verticalSize: 13,
+};
+
+export default GroupTooltip;

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -9,72 +9,72 @@ import ToolTipTSpanLabel from "./ToolTipTSpanLabel";
 import { functor } from "../utils";
 
 class SingleTooltip extends Component {
-    
-    constructor(props) {
-        super(props);
-        this.handleClick = this.handleClick.bind(this);
+
+    constructor( props ) {
+        super( props );
+        this.handleClick = this.handleClick.bind( this );
     }
-    
-    handleClick(e) {
+
+    handleClick( e ) {
         const { onClick, forChart, options } = this.props;
-        onClick({ chartId: forChart, ...options }, e);
+        onClick( { chartId: forChart, ...options }, e );
     }
-    
+
     /**
      * Renders the value next to the label.
      */
-    renderValueNextToLabel(){
+    renderValueNextToLabel() {
         const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
 
         return (
-                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
+            <g transform={`translate(${origin[0]}, ${origin[1]})`} onClick={this.handleClick}>
                 {withShape ? <rect x="0" y="-6" width="6" height="6" fill={valueFill} /> : null}
                 <ToolTipText x={withShape ? 8 : 0} y={0} fontFamily={fontFamily} fontSize={fontSize}>
                     <ToolTipTSpanLabel fill={labelFill}>{yLabel}: </ToolTipTSpanLabel>
                     <tspan fill={valueFill}>{yValue}</tspan>
                 </ToolTipText>
-                </g>
-               )
+            </g>
+        )
     }
-    
+
     /**
      * Renders the value beneath the label.
      */
-    renderValueBeneathToLabel(){
+    renderValueBeneathToLabel() {
         const { origin, yLabel, yValue, labelFill, valueFill, withShape, fontSize, fontFamily } = this.props;
 
         return (
-                <g transform={`translate(${ origin[0] }, ${origin[1] })`} onClick={this.handleClick}>
-                {withShape ? <line x1={0} y1={2} x2={0} y2={28} stroke={valueFill} strokeWidth="4px"/> : null}
+            <g transform={`translate(${origin[0]}, ${origin[1]})`} onClick={this.handleClick}>
+                {withShape ? <line x1={0} y1={2} x2={0} y2={28} stroke={valueFill} strokeWidth="4px" /> : null}
                 <ToolTipText x={5} y={11} fontFamily={fontFamily} fontSize={fontSize}>
                     <ToolTipTSpanLabel fill={labelFill}>{yLabel}</ToolTipTSpanLabel>
                     <tspan x="5" dy="15" fill={valueFill}>{yValue}</tspan>
                 </ToolTipText>
-                </g>
-               )
+            </g>
+        )
     }
-    
+
     /**
      * Renders the value next to the label. 
      * The parent component must have a "text"-element.
      */
-    renderInline(){
+    renderInline() {
         const { yLabel, yValue, labelFill, valueFill, fontSize, fontFamily } = this.props;
-        
+
         return (
-                <tspan onClick={this.handleClick} fontFamily={fontFamily} fontSize={fontSize}>
-                    <ToolTipTSpanLabel fill={labelFill}>{yLabel}:&nbsp;</ToolTipTSpanLabel>
-                    <tspan fill={valueFill}>{yValue} &nbsp;&nbsp;</tspan>
-                </tspan>
-               )
+            <tspan onClick={this.handleClick} fontFamily={fontFamily} fontSize={fontSize}>
+                <ToolTipTSpanLabel fill={labelFill}>{yLabel}:&nbsp;</ToolTipTSpanLabel>
+                <tspan fill={valueFill}>{yValue}&nbsp;&nbsp;</tspan>
+            </tspan>
+        )
     }
 
     render() {
-        
+
         const { layout } = this.props;
         let comp = null;
-        
-        switch (layout) {
+
+        switch ( layout ) {
             case "horizontal":
                 comp = this.renderValueNextToLabel();
                 break;
@@ -99,78 +99,78 @@ class SingleTooltip extends Component {
 }
 
 SingleTooltip.propTypes = {
-        origin: PropTypes.array.isRequired,
-        yLabel: PropTypes.string.isRequired,
-        yValue: PropTypes.string.isRequired,
-        onClick: PropTypes.func,
-        fontFamily: PropTypes.string,
-        labelFill: PropTypes.string.isRequired,
-        valueFill: PropTypes.string.isRequired,
-        fontSize: PropTypes.number,
-        withShape: PropTypes.bool,
-        forChart: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
-        options: PropTypes.object.isRequired,
+    origin: PropTypes.array.isRequired,
+    yLabel: PropTypes.string.isRequired,
+    yValue: PropTypes.string.isRequired,
+    onClick: PropTypes.func,
+    fontFamily: PropTypes.string,
+    labelFill: PropTypes.string.isRequired,
+    valueFill: PropTypes.string.isRequired,
+    fontSize: PropTypes.number,
+    withShape: PropTypes.bool,
+    forChart: PropTypes.oneOfType( [PropTypes.number, PropTypes.string] ).isRequired,
+    options: PropTypes.object.isRequired,
 };
 
 SingleTooltip.defaultProps = {
-        labelFill: "#4682B4",
-        valueFill: "#000000",
-        withShape: false,
+    labelFill: "#4682B4",
+    valueFill: "#000000",
+    withShape: false,
 };
 
 class GroupTooltip extends Component {
-    constructor(props) {
-        super(props);
-        this.renderSVG = this.renderSVG.bind(this);
+    constructor( props ) {
+        super( props );
+        this.renderSVG = this.renderSVG.bind( this );
     }
-    renderSVG(moreProps) {
-        
+    renderSVG( moreProps ) {
+
         const { displayValuesFor } = this.props;
         const { chartId } = moreProps;
 
         const { className, onClick, width, verticalSize, fontFamily, fontSize, layout } = this.props;
         const { origin, displayFormat, options } = this.props;
-        const currentItem = displayValuesFor(this.props, moreProps);
-        
-        const singleTooltip = options.map((each, idx) => {
-                        
-                    const yValue = currentItem && each.yAccessor(currentItem);
-                    const yDisplayValue = yValue ? displayFormat(yValue) : "n/a";
+        const currentItem = displayValuesFor( this.props, moreProps );
 
-                    const orig = () => {
-                        if(layout == "horizontal" || layout == "horizontalRows"){
-                            return [width * idx, 0];
-                        }
-                        if(layout == "vertical"){
-                            return [0, verticalSize * idx];
-                        }
-                        if(layout == "verticalRows"){
-                            return [0, verticalSize * 2.3 * idx];
-                        }
-                        return [0, 0];
-                    }
+        const singleTooltip = options.map( ( each, idx ) => {
 
-                    return <SingleTooltip
-                            key={idx}
-                            layout={layout}
-                            origin={orig()} 
-                            yLabel={each.yLabel}
-                            yValue={yDisplayValue}
-                            options={each}
-                            forChart={chartId}
-                            onClick={onClick}
-                            fontFamily={fontFamily}
-                            fontSize={fontSize}
-                            labelFill={each.labelFill}
-                            valueFill={each.valueFill}
-                            withShape={each.withShape}
-                            />;
-                });
-        
+            const yValue = currentItem && each.yAccessor( currentItem );
+            const yDisplayValue = yValue ? displayFormat( yValue ) : "n/a";
+
+            const orig = () => {
+                if ( layout == "horizontal" || layout == "horizontalRows" ) {
+                    return [width * idx, 0];
+                }
+                if ( layout == "vertical" ) {
+                    return [0, verticalSize * idx];
+                }
+                if ( layout == "verticalRows" ) {
+                    return [0, verticalSize * 2.3 * idx];
+                }
+                return [0, 0];
+            }
+
+            return <SingleTooltip
+                key={idx}
+                layout={layout}
+                origin={orig()}
+                yLabel={each.yLabel}
+                yValue={yDisplayValue}
+                options={each}
+                forChart={chartId}
+                onClick={onClick}
+                fontFamily={fontFamily}
+                fontSize={fontSize}
+                labelFill={each.labelFill}
+                valueFill={each.valueFill}
+                withShape={each.withShape}
+            />;
+        } );
+
         return (
-            <g transform={`translate(${ origin[0] }, ${origin[1] })`} className={className}>
+            <g transform={`translate(${origin[0]}, ${origin[1]})`} className={className}>
                 {layout == "horizontalInline"
-                    ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText> 
+                    ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText>
                     : singleTooltip
                 }
             </g>
@@ -187,12 +187,20 @@ class GroupTooltip extends Component {
 
 GroupTooltip.propTypes = {
     className: PropTypes.string,
-    layout: PropTypes.oneOf([
-        "horizontal", 
-        "horizontalRows", 
-        "horizontalInline", 
-        "vertical", 
-        "verticalRows"]).isRequired,
+    layout: PropTypes.oneOf( [
+        "horizontal",
+        "horizontalRows",
+        "horizontalInline",
+        "vertical",
+        "verticalRows"] ).isRequired,
+    // TODO: please implement this
+    position: PropTypes.oneOf( [
+        "topLeft",
+        "topRight",
+        "topCenter",
+        "bottomLeft",
+        "bottomRight",
+        "bottomCenter"] ).isRequired,
     displayFormat: PropTypes.func.isRequired,
     origin: PropTypes.array.isRequired,
     displayValuesFor: PropTypes.func,
@@ -201,24 +209,25 @@ GroupTooltip.propTypes = {
     fontSize: PropTypes.number,
     width: PropTypes.number, // "width" only be used, if layout is "horizontal" or "horizontalRows".
     verticalSize: PropTypes.number,  // "verticalSize" only be used, if layout is "vertical", "verticalRows".
-    options: PropTypes.arrayOf(PropTypes.shape({
-        yLabel: PropTypes.oneOfType([
-                PropTypes.string,
-                PropTypes.func]).isRequired,
+    options: PropTypes.arrayOf( PropTypes.shape( {
+        yLabel: PropTypes.oneOfType( [
+            PropTypes.string,
+            PropTypes.func] ).isRequired,
         yAccessor: PropTypes.func.isRequired,
         labelFill: PropTypes.string,
         valueFill: PropTypes.string,
         withShape: PropTypes.bool, // "withShape" is ignored, if layout is "horizontalInline" or "vertical".
-    })),
+    } ) ),
 };
 
 GroupTooltip.defaultProps = {
     className: "react-stockcharts-tooltip react-stockcharts-group-tooltip",
     layout: "horizontal",
-    displayFormat: format(".2f"),
+    position: "topLeft",
+    displayFormat: format( ".2f" ),
     displayValuesFor: displayValuesFor,
     origin: [0, 0],
-    width: 60, 
+    width: 60,
     verticalSize: 13,
 };
 

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -123,6 +123,41 @@ class GroupTooltip extends Component {
         super( props );
         this.renderSVG = this.renderSVG.bind( this );
     }
+    
+    // TODO: please implement this
+    // the retuned x-y-array must have the right x and y
+    // for the translate-property of the groupTooltip-component.
+    getPosition(props) {
+        const { position } = this.props;
+        let xyPos = [];
+
+        switch ( layout ) {
+            case "topLeft":
+                xyPos = [0, 0];
+                break;
+            case "topRight":
+                xyPos = [0, 0];
+                break;
+            case "topCenter":
+                xyPos = [0, 0];
+                break;
+            case "bottomLeft":
+                xyPos = [0, 0];
+                break;
+            case "bottomRight":
+                xyPos = [0, 0];
+                break;
+            case "bottomCenter":
+                xyPos = [0, 0];
+                break;
+            default:
+                xyPos = [0, 0];
+        }
+
+        return xyPos;
+    }
+    
+    
     renderSVG( moreProps ) {
 
         const { displayValuesFor } = this.props;
@@ -131,6 +166,8 @@ class GroupTooltip extends Component {
         const { className, onClick, width, verticalSize, fontFamily, fontSize, layout } = this.props;
         const { origin, displayFormat, options } = this.props;
         const currentItem = displayValuesFor( this.props, moreProps );
+        // TODO: implement this.getPosition(props)
+        const xyPos = this.getPosition(props);
 
         const singleTooltip = options.map( ( each, idx ) => {
 
@@ -168,6 +205,7 @@ class GroupTooltip extends Component {
         } );
 
         return (
+            // TODO: use xyPos-array for transform-property
             <g transform={`translate(${origin[0]}, ${origin[1]})`} className={className}>
                 {layout == "horizontalInline"
                     ? <ToolTipText x={0} y={0} fontFamily={fontFamily} fontSize={fontSize}>{singleTooltip}</ToolTipText>
@@ -193,7 +231,6 @@ GroupTooltip.propTypes = {
         "horizontalInline",
         "vertical",
         "verticalRows"] ).isRequired,
-    // TODO: please implement this
     position: PropTypes.oneOf( [
         "topLeft",
         "topRight",

--- a/src/lib/tooltip/GroupTooltip.js
+++ b/src/lib/tooltip/GroupTooltip.js
@@ -127,11 +127,11 @@ class GroupTooltip extends Component {
     // TODO: please implement this
     // the retuned x-y-array must have the right x and y
     // for the translate-property of the groupTooltip-component.
-    getPosition(props) {
+    getPosition() {
         const { position } = this.props;
         let xyPos = [];
 
-        switch ( layout ) {
+        switch ( position ) {
             case "topLeft":
                 xyPos = [0, 0];
                 break;
@@ -167,7 +167,7 @@ class GroupTooltip extends Component {
         const { origin, displayFormat, options } = this.props;
         const currentItem = displayValuesFor( this.props, moreProps );
         // TODO: implement this.getPosition(props)
-        const xyPos = this.getPosition(props);
+        const xyPos = this.getPosition();
 
         const singleTooltip = options.map( ( each, idx ) => {
 
@@ -231,6 +231,7 @@ GroupTooltip.propTypes = {
         "horizontalInline",
         "vertical",
         "verticalRows"] ).isRequired,
+    // TODO: please implement this
     position: PropTypes.oneOf( [
         "topLeft",
         "topRight",


### PR DESCRIPTION
With "Cursor.js", the x and y cursor can be styled individually.

The former "CrosshairCursor.js" can be removed from the repo, because with this:

`<Cursor strokeDasharray="Solid" stroke="#ccc" opacity={0.3} />`

we have a common crosshair-cursor.

With this, we have the y-cursor disabled:
`
<Cursor disableYCursor={false} />`


and with this, we have the y-cursor disabled and x-cursor uses shape (rect) instead of line (the shape can be styled indiviudally (shapeStroke, shapeOpacity, shapeFill):

`<Cursor strokeDasharray="Solid" stroke="#ccc" useXCursorShape={false} xCursorShapeOpacity={0.1} disableYCursor={false} opacity={0.3} />`

and using this, sets the "xCursorShapeColor" in relation to the actual tick:

```
<Cursor strokeDasharray="Solid" 
                        stroke="#ccc" 
                        useXCursorShape={true} 
                        xCursorShapeStrokeDasharray="Solid"
                        xCursorShapeFill={d => (d.close > d.open ? "#6BA583" : "#FF0000")} 
                        xCursorShapeStroke={d => (d.close > d.open ? "#6BA583" : "#FF0000")}  
                        xCursorShapeOpacity={0.2} 
                        disableYCursor={true} />
```

You can even disable "xCursorShapeFill - then only the "stroke" of xCursor is shown and the shapeFill becomes transparent (you can also disable "xCursorShapeStrokeDasharray"):


```
<Cursor strokeDasharray="Solid" 
                        stroke="#ccc" 
                        useXCursorShape={true} 
                        xCursorShapeStrokeDasharray="Solid"
                        xCursorShapeStroke={d => (d.close > d.open ? "#6BA583" : "#FF0000")}  
                        xCursorShapeOpacity={0.2} 
                        disableYCursor={true} />
```

All works fine and fast. 

One question: For what are these two properties (coming from CrosshairCursor):
```
	snapX: true,
	customX,
```
  
  
  