### PR TITLE
Add option to disable chart interaction

### DIFF
--- a/src/lib/ChartCanvas.js
+++ b/src/lib/ChartCanvas.js
@@ -1086,6 +1086,7 @@ class ChartCanvas extends Component {
 							xScale={xScale}
 							xAccessor={xAccessor}
 							focus={defaultFocus}
+							disableInteraction={this.props.disableInteraction}
 
 							getAllPanConditions={this.getAllPanConditions}
 							onContextMenu={this.handleContextMenu}
@@ -1200,6 +1201,7 @@ ChartCanvas.defaultProps = {
 	zoomAnchor: mouseBasedZoomAnchor,
 	maintainPointsPerPixelOnResize: true,
 	// ratio: 2,
+	disableInteraction: false,
 };
 
 ChartCanvas.childContextTypes = {
@@ -1245,6 +1247,7 @@ ChartCanvas.childContextTypes = {
 	setCursorClass: PropTypes.func,
 	generateSubscriptionId: PropTypes.func,
 	getMutableState: PropTypes.func,
+	disableInteraction: PropTypes.bool,
 };
 
 ChartCanvas.ohlcv = d => ({ date: d.date, open: d.open, high: d.high, low: d.low, close: d.close, volume: d.volume });

--- a/src/lib/EventCapture.js
+++ b/src/lib/EventCapture.js
@@ -513,12 +513,20 @@ class EventCapture extends Component {
 		}
 	}
 	render() {
-		const { height, width } = this.props;
+		const { height, width, disableInteraction } = this.props;
 		const className = this.state.cursorOverrideClass != null
 			? this.state.cursorOverrideClass
 			: this.state.panInProgress
 				? "react-stockcharts-grabbing-cursor"
 				: "react-stockcharts-crosshair-cursor";
+
+		const interactionProps = disableInteraction || {
+			onWheel: this.handleWheel,
+			onMouseDown: this.handleMouseDown,
+			onClick: this.handleClick,
+			onContextMenu: this.handleContextMenu,
+			onTouchStart: this.handleTouchStart,
+		};
 
 		return (
 			<rect ref={this.saveNode}
@@ -526,11 +534,7 @@ class EventCapture extends Component {
 				width={width}
 				height={height}
 				style={{ opacity: 0 }}
-				onWheel={this.handleWheel}
-				onMouseDown={this.handleMouseDown}
-				onClick={this.handleClick}
-				onContextMenu={this.handleRightClick}
-				onTouchStart={this.handleTouchStart}
+				{...interactionProps}
 			/>
 		);
 	}
@@ -552,6 +556,7 @@ EventCapture.propTypes = {
 	chartConfig: PropTypes.array,
 	xScale: PropTypes.func.isRequired,
 	xAccessor: PropTypes.func.isRequired,
+	disableInteraction: PropTypes.bool.isRequired,
 
 	getAllPanConditions: PropTypes.func.isRequired,
 
@@ -581,6 +586,7 @@ EventCapture.defaultProps = {
 	panSpeedMultiplier: 1,
 	focus: false,
 	onDragComplete: noop,
+	disableInteraction: false,
 };
 
 export default EventCapture;


### PR DESCRIPTION
@rrag We have a use case where we display multiple stock charts in a scrollable list and we want to be able to smoothly scroll through that list. `EventCapture` was always calling `preventDefault` on the scroll event, so the scrolling would stop when the cursor entered a graph, even when the zoom and pan events were disabled. Let me know if there's a better way to do this, then I can write up some docs and add a small example.