### PR TITLE
Implement a case for 'clamp' ChartCanvas property as function

### DIFF
--- a/src/lib/ChartCanvas.js
+++ b/src/lib/ChartCanvas.js
@@ -1173,7 +1173,7 @@ ChartCanvas.propTypes = {
 	},
 	mouseMoveEvent: PropTypes.bool,
 	panEvent: PropTypes.bool,
-	clamp: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+	clamp: PropTypes.oneOfType([PropTypes.string, PropTypes.bool, PropTypes.func]),
 	zoomEvent: PropTypes.bool,
 	onSelect: PropTypes.func,
 	maintainPointsPerPixelOnResize: PropTypes.bool,

--- a/src/lib/scale/evaluator.js
+++ b/src/lib/scale/evaluator.js
@@ -48,17 +48,26 @@ function extentsWrapper(useWholeData, clamp, pointsPerPxThreshold, minPointsPerP
 			filteredData = getFilteredResponse(data, left, right, xAccessor);
 		}
 
-		if (clamp === "left" || clamp === "both" || clamp === true) {
-			clampedDomain = [
-				Math.max(left, xAccessor(head(data))),
-				clampedDomain[1]
-			];
+		if (typeof clamp === 'function') {
+			clampedDomain = clamp(clampedDomain, [xAccessor(head(data)), xAccessor(last(data))]);
+		} else {
+			if (clamp === "left" || clamp === "both" || clamp === true) {
+				clampedDomain = [
+					Math.max(left, xAccessor(head(data))),
+					clampedDomain[1]
+				];
+			}
+
+			if (clamp === "right" || clamp === "both" || clamp === true) {
+				clampedDomain = [
+					clampedDomain[0],
+					Math.min(right, xAccessor(last(data)))
+				];
+			}
 		}
-		if (clamp === "right" || clamp === "both" || clamp === true) {
-			clampedDomain = [
-				clampedDomain[0],
-				Math.min(right, xAccessor(last(data)))
-			];
+
+		if (clampedDomain !== inputDomain) {
+			filteredData = getFilteredResponse(data, clampedDomain[0], clampedDomain[1], xAccessor);
 		}
 
 		const realInputDomain = clampedDomain;


### PR DESCRIPTION
Implement a case for 'clamp' ChartCanvas property as function, to use some custom clamp logic.
For example, logic to restrict scroll to left by some condition - by more data availability: if there are more data on server, then leave clampedDomain as is, and load more data on onLoadMoreData event.
Otherwise, fix clampedDomain to fit data domain left bound.