### PR TITLE
Added missing strokeDasharray to component/StraightLine.js

### DIFF
--- a/src/lib/interactive/components/StraightLine.js
+++ b/src/lib/interactive/components/StraightLine.js
@@ -58,7 +58,7 @@ class StraightLine extends Component {
 		ctx.stroke();
 	}
 	renderSVG(moreProps) {
-		const { stroke, strokeWidth, strokeOpacity } = this.props;
+		const { stroke, strokeWidth, strokeOpacity, strokeDasharray } = this.props;
 
 		const lineWidth = strokeWidth;
 
@@ -67,6 +67,7 @@ class StraightLine extends Component {
 			<line
 				x1={x1} y1={y1} x2={x2} y2={y2}
 				stroke={stroke} strokeWidth={lineWidth}
+            	strokeDasharray={getStrokeDasharray(strokeDasharray)}
 				strokeOpacity={strokeOpacity} />
 		);
 	}


### PR DESCRIPTION
Added missing `strokeDasharray` to the SVG renderer.