### PR TITLE
Fixes the proptype warning for macd chart in fill.divergence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 build
+.idea
 .tmp
 .sass-cache
 /tmp

--- a/src/lib/series/MACDSeries.js
+++ b/src/lib/series/MACDSeries.js
@@ -78,7 +78,7 @@ MACDSeries.propTypes = {
 		signal: PropTypes.string.isRequired,
 	}).isRequired,
 	fill: PropTypes.shape({
-		divergence: PropTypes.string.isRequired,
+		divergence: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
 	}).isRequired,
 };
 


### PR DESCRIPTION
Resolves https://github.com/rrag/react-stockcharts/issues/524#issuecomment-379514869 