### PR TITLE
Update the propTypes of LabelAnnotaion text attr to support both string and func

### DIFF
--- a/src/lib/annotation/LabelAnnotation.js
+++ b/src/lib/annotation/LabelAnnotation.js
@@ -55,7 +55,10 @@ export function helper(props, xAccessor, xScale, yScale) {
 
 LabelAnnotation.propTypes = {
 	className: PropTypes.string,
-	text: PropTypes.string,
+	text: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.func
+	]),
 	textAnchor: PropTypes.string,
 	fontFamily: PropTypes.string,
 	fontSize: PropTypes.number,


### PR DESCRIPTION
The text attribute allow string and function. But the propType only contains string.
It will alert at the console.
Just update the propType of the text attribute can fix this alert.