### PR TITLE
update save-svg-as-png to ES5 supported version to fix CRA minifying issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "debug": "^3.1.0",
     "lodash.flattendeep": "^4.4.0",
     "prop-types": "^15.6.0",
-    "save-svg-as-png": "^1.2.0"
+    "save-svg-as-png": "^1.4.3"
   },
   "peerDependencies": {
     "react": "^15.0.0 || ^16.0.0",


### PR DESCRIPTION
as per https://github.com/exupero/saveSvgAsPng/issues/171#issuecomment-393503542 issue, as well as fixes https://github.com/rrag/react-stockcharts/issues/567

Thanks @rrag  for you review 