### PR TITLE
Add wheelPanDirection prop to EventCapture.

### DIFF
--- a/src/lib/ChartCanvas.js
+++ b/src/lib/ChartCanvas.js
@@ -1049,7 +1049,7 @@ class ChartCanvas extends Component {
 	}
 	render() {
 
-		const { type, height, width, margin, className, zIndex, defaultFocus, ratio, mouseMoveEvent, panEvent, zoomEvent } = this.props;
+		const { type, height, width, margin, className, zIndex, defaultFocus, ratio, mouseMoveEvent, panEvent, zoomEvent, wheelPanDirection } = this.props;
 		const { useCrossHairStyleCursor, onSelect } = this.props;
 
 		const { plotData, xScale, xAccessor, chartConfig } = this.state;
@@ -1083,6 +1083,7 @@ class ChartCanvas extends Component {
 							mouseMove={mouseMoveEvent && interaction}
 							zoom={zoomEvent && interaction}
 							pan={panEvent && interaction}
+							wheelPanDirection={wheelPanDirection}
 
 							width={dimensions.width}
 							height={dimensions.height}
@@ -1180,6 +1181,7 @@ ChartCanvas.propTypes = {
 	onSelect: PropTypes.func,
 	maintainPointsPerPixelOnResize: PropTypes.bool,
 	disableInteraction: PropTypes.bool,
+	wheelPanDirection: PropTypes.string,
 };
 
 ChartCanvas.defaultProps = {
@@ -1207,6 +1209,7 @@ ChartCanvas.defaultProps = {
 	maintainPointsPerPixelOnResize: true,
 	// ratio: 2,
 	disableInteraction: false,
+	wheelPanDirection: 'forward',
 };
 
 ChartCanvas.childContextTypes = {

--- a/src/lib/EventCapture.js
+++ b/src/lib/EventCapture.js
@@ -126,7 +126,7 @@ class EventCapture extends Component {
 				if (wheelPanDirection === 'forward') {
 					this.dx += e.deltaX;
 				} else {
-					this.dx += e.deltaX;
+					this.dx -= e.deltaX;
 				}
 				this.dy += e.deltaY;
 				const dxdy = { dx: this.dx, dy: this.dy };

--- a/src/lib/EventCapture.js
+++ b/src/lib/EventCapture.js
@@ -100,7 +100,7 @@ class EventCapture extends Component {
 		onMouseLeave(e);
 	}
 	handleWheel(e) {
-		const { zoom, onZoom } = this.props;
+		const { zoom, onZoom, wheelPanDirection } = this.props;
 		const { panInProgress } = this.state;
 
 		const yZoom = Math.abs(e.deltaY) > Math.abs(e.deltaX) && Math.abs(e.deltaY) > 0;
@@ -123,7 +123,11 @@ class EventCapture extends Component {
 				this.lastNewPos = mouseXY;
 				this.panHappened = true;
 
-				this.dx += e.deltaX;
+				if (wheelPanDirection === 'forward') {
+					this.dx += e.deltaX;
+				} else {
+					this.dx += e.deltaX;
+				}
 				this.dy += e.deltaY;
 				const dxdy = { dx: this.dx, dy: this.dy };
 


### PR DESCRIPTION
Now, the touch pad event  pan direction is related to the time axis, but many candlestick chart will related to the chart self.

So I add the `wheelPanDirection` that can be 'reverse` and `forward`. When the `wheelPanDirection` is `reverse`, then user pan the chart that use touch pad will move related to the chart self.