### PR TITLE
Add candle border radius to Candle Series

### DIFF
--- a/docs/md/CANDLESTICK-IMPROVED.md
+++ b/docs/md/CANDLESTICK-IMPROVED.md
@@ -86,12 +86,12 @@ const candlesAppearance = {
   candleStrokeWidth: 1,
   widthRatio: 0.8,
   opacity: 1,
+  candleBorderRadius: 2
 }
 ``
 
-Then, make sure to rendre the CandlestickSeries component as such:
+Then, make sure to render the CandlestickSeries component as such:
 
 ```
-<CandlestickSeries
-   {...candlesAppearance} />
+<CandlestickSeries {...candlesAppearance} />
 ```

--- a/docs/md/CANDLESTICK-IMPROVED.md
+++ b/docs/md/CANDLESTICK-IMPROVED.md
@@ -88,7 +88,7 @@ const candlesAppearance = {
   opacity: 1,
   candleBorderRadius: 2
 }
-``
+```
 
 Then, make sure to render the CandlestickSeries component as such:
 

--- a/src/lib/series/CandlestickSeries.js
+++ b/src/lib/series/CandlestickSeries.js
@@ -74,6 +74,8 @@ CandlestickSeries.propTypes = {
 		PropTypes.func,
 		PropTypes.string
 	]),
+	candleStrokeWidth: PropTypes.number,
+	candleBorderRadius: PropTypes.number,
 	yAccessor: PropTypes.func,
 	clip: PropTypes.bool,
 };
@@ -91,6 +93,7 @@ CandlestickSeries.defaultProps = {
 	// stroke: d => d.close > d.open ? "#6BA583" : "#FF0000",
 	stroke: "#000000",
 	candleStrokeWidth: 0.5,
+	candleBorderRadius: 0,
 	// stroke: "none",
 	widthRatio: 0.8,
 	opacity: 0.5,
@@ -114,7 +117,7 @@ function getWicksSVG(candleData) {
 function getCandlesSVG(props, candleData) {
 
 	/* eslint-disable react/prop-types */
-	const { opacity, candleStrokeWidth } = props;
+	const { opacity, candleStrokeWidth, candleBorderRadius } = props;
 	/* eslint-enable react/prop-types */
 
 	const candles = candleData.map((d, idx) => {
@@ -134,7 +137,8 @@ function getCandlesSVG(props, candleData) {
 			<rect key={idx} className={d.className}
 				fillOpacity={opacity}
 				x={d.x} y={d.y} width={d.width} height={d.height}
-				fill={d.fill} stroke={d.stroke} strokeWidth={candleStrokeWidth} />
+				fill={d.fill} stroke={d.stroke} strokeWidth={candleStrokeWidth}
+				rx={candleBorderRadius} ry={candleBorderRadius} />
 		);
 	});
 	return candles;


### PR DESCRIPTION
Adds a `candleBorderRadius` prop to the `CandleSeries` component that sets the radius of the candle borders. This is the first option presented in #610 and is the least intrusive.