### PR TITLE
autowidth and autoheight for hoverText in InteractiveText, TrendLine, FibonacciRetracement

### DIFF
--- a/src/lib/interactive/FibonacciRetracement.js
+++ b/src/lib/interactive/FibonacciRetracement.js
@@ -172,13 +172,17 @@ class FibonacciRetracement extends Component {
 
 		const { enabled, hoverText } = this.props;
 		const overrideIndex = isDefined(override) ? override.index : null;
+		const hoverTextWidthDefault = {
+			...FibonacciRetracement.defaultProps.hoverText,
+			...hoverText
+		};
 
 		const currentRetracement = isDefined(current) && isDefined(current.x2)
 			? <EachFibRetracement
 				interactive={false}
 				type={type}
 				appearance={appearance}
-				hoverText={hoverText}
+				hoverText={hoverTextWidthDefault}
 				{...current}
 			/>
 			: null;
@@ -189,6 +193,10 @@ class FibonacciRetracement extends Component {
 						? { ...appearance, ...each.appearance }
 						: appearance;
 
+					const eachHoverText = isDefined(each.hoverText)
+						? { ...hoverTextWidthDefault, ...each.hoverText }
+						: hoverTextWidthDefault;
+
 					return (
 						<EachFibRetracement
 							key={idx}
@@ -196,8 +204,8 @@ class FibonacciRetracement extends Component {
 							index={idx}
 							type={each.type}
 							selected={each.selected}
-							hoverText={hoverText}
 							{...(idx === overrideIndex ? override : each)}
+							hoverText={eachHoverText}							
 							appearance={eachAppearance}
 							onDrag={this.handleDrag}
 							onDragComplete={this.handleDragComplete}
@@ -272,8 +280,8 @@ FibonacciRetracement.defaultProps = {
 	hoverText: {
 		...HoverTextNearMouse.defaultProps,
 		enable: true,
-		bgHeight: 18,
-		bgWidth: 120,
+		bgHeight: 'auto',
+		bgWidth: 'auto',
 		text: "Click to select object"
 	},
 	currentPositionStroke: "#000000",

--- a/src/lib/interactive/InteractiveText.js
+++ b/src/lib/interactive/InteractiveText.js
@@ -101,13 +101,19 @@ class InteractiveText extends Component {
 		} */
 	}
 	render() {
-		const { textList, defaultText } = this.props;
+		const { textList, defaultText, hoverText } = this.props;
 		const { override } = this.state;
 		return <g>
 			{textList.map((each, idx) => {
+				const defaultHoverText = InteractiveText.defaultProps.hoverText;
 				const props = {
 					...defaultText,
 					...each,
+					hoverText: {
+						...defaultHoverText,
+						...hoverText,
+						...(each.hoverText || {})
+					},
 				};
 				return <EachText key={idx}
 					ref={this.saveNodeType(idx)}
@@ -143,6 +149,8 @@ InteractiveText.propTypes = {
 	defaultText: PropTypes.shape({
 		bgFill: PropTypes.string.isRequired,
 		bgOpacity: PropTypes.number.isRequired,
+		bgStrokeWidth: PropTypes.number,
+		bgStroke: PropTypes.string,
 		textFill: PropTypes.string.isRequired,
 		fontFamily: PropTypes.string.isRequired,
 		fontWeight: PropTypes.string.isRequired,
@@ -164,6 +172,7 @@ InteractiveText.defaultProps = {
 	defaultText: {
 		bgFill: "#D3D3D3",
 		bgOpacity: 1,
+		bgStrokeWidth: 1,
 		textFill: "#F10040",
 		fontFamily: "Helvetica Neue, Helvetica, Arial, sans-serif",
 		fontSize: 12,
@@ -174,9 +183,10 @@ InteractiveText.defaultProps = {
 	hoverText: {
 		...HoverTextNearMouse.defaultProps,
 		enable: true,
-		bgHeight: 18,
-		bgWidth: 175,
-		text: "Click and drag the edge circles",
+		bgHeight: "auto",
+		bgWidth: "auto",
+		text: "Click to select object",
+		selectedText: "",
 	},
 	textList: [],
 };

--- a/src/lib/interactive/StandardDeviationChannel.js
+++ b/src/lib/interactive/StandardDeviationChannel.js
@@ -126,21 +126,35 @@ class StandardDeviationChannel extends Component {
 		const { hoverText, channels } = this.props;
 		const { current, override } = this.state;
 
+		const eachDefaultAppearance = {
+			...StandardDeviationChannel.defaultProps.appearance,
+			...appearance
+		};
+
+		const hoverTextDefault = {
+			...StandardDeviationChannel.defaultProps.hoverText,
+			...hoverText
+		};
+
 		const tempLine = isDefined(current) && isDefined(current.end)
 			? <EachLinearRegressionChannel
 				interactive={false}
 				x1Value={current.start[0]}
 				x2Value={current.end[0]}
-				appearance={appearance}
-				hoverText={hoverText}
+				appearance={eachDefaultAppearance}
+				hoverText={hoverTextDefault}
 			/>
 			: null;
 
 		return <g>
 			{channels.map((each, idx) => {
 				const eachAppearance = isDefined(each.appearance)
-					? { ...appearance, ...each.appearance }
-					: appearance;
+					? { ...eachDefaultAppearance, ...each.appearance }
+					: eachDefaultAppearance;
+
+				const eachHoverText = isDefined(each.hoverText)
+					? { ...hoverTextDefault, ...each.hoverText }
+					: hoverTextDefault;
 
 				return <EachLinearRegressionChannel key={idx}
 					ref={this.saveNodeType(idx)}
@@ -152,7 +166,7 @@ class StandardDeviationChannel extends Component {
 
 					appearance={eachAppearance}
 					snapTo={snapTo}
-					hoverText={hoverText}
+					hoverText={eachHoverText}
 
 					onDrag={this.handleDragLine}
 					onDragComplete={this.handleDragLineComplete}
@@ -178,9 +192,9 @@ class StandardDeviationChannel extends Component {
 
 StandardDeviationChannel.propTypes = {
 	enabled: PropTypes.bool.isRequired,
-	snapTo: PropTypes.func.isRequired,
+	snapTo: PropTypes.func,
 
-	onStart: PropTypes.func.isRequired,
+	onStart: PropTypes.func,
 	onComplete: PropTypes.func.isRequired,
 	onSelect: PropTypes.func,
 
@@ -190,18 +204,18 @@ StandardDeviationChannel.propTypes = {
 	currentPositionRadius: PropTypes.number,
 
 	appearance: PropTypes.shape({
-		stroke: PropTypes.string.isRequired,
-		strokeOpacity: PropTypes.number.isRequired,
-		strokeWidth: PropTypes.number.isRequired,
-		fill: PropTypes.string.isRequired,
-		fillOpacity: PropTypes.number.isRequired,
-		edgeStrokeWidth: PropTypes.number.isRequired,
-		edgeStroke: PropTypes.string.isRequired,
-		edgeFill: PropTypes.string.isRequired,
-		r: PropTypes.number.isRequired,
+		stroke: PropTypes.string,
+		strokeOpacity: PropTypes.number,
+		strokeWidth: PropTypes.number,
+		fill: PropTypes.string,
+		fillOpacity: PropTypes.number,
+		edgeStrokeWidth: PropTypes.number,
+		edgeStroke: PropTypes.string,
+		edgeFill: PropTypes.string,
+		r: PropTypes.number,
 	}).isRequired,
 
-	hoverText: PropTypes.object.isRequired,
+	hoverText: PropTypes.object,
 	channels: PropTypes.array.isRequired,
 };
 
@@ -231,9 +245,10 @@ StandardDeviationChannel.defaultProps = {
 	hoverText: {
 		...HoverTextNearMouse.defaultProps,
 		enable: true,
-		bgHeight: 18,
-		bgWidth: 175,
+		bgHeight: 'auto',
+		bgWidth: 'auto',
 		text: "Click and drag the edge circles",
+		selectedText: ''
 	},
 	channels: [],
 };

--- a/src/lib/interactive/TrendLine.js
+++ b/src/lib/interactive/TrendLine.js
@@ -149,6 +149,11 @@ class TrendLine extends Component {
 					? { ...appearance, ...each.appearance }
 					: appearance;
 
+				const hoverTextWithDefault = {
+					...TrendLine.defaultProps.hoverText,
+					...hoverText
+				};
+
 				return <EachTrendLine key={idx}
 					ref={this.saveNodeType(idx)}
 					index={idx}
@@ -166,7 +171,7 @@ class TrendLine extends Component {
 					edgeFill={eachAppearance.edgeFill}
 					edgeStrokeWidth={eachAppearance.edgeStrokeWidth}
 					r={eachAppearance.r}
-					hoverText={hoverText}
+					hoverText={hoverTextWithDefault}
 					onDrag={this.handleDragLine}
 					onDragComplete={this.handleDragLineComplete}
 					edgeInteractiveCursor="react-stockcharts-move-cursor"
@@ -242,9 +247,10 @@ TrendLine.defaultProps = {
 	hoverText: {
 		...HoverTextNearMouse.defaultProps,
 		enable: true,
-		bgHeight: 18,
-		bgWidth: 120,
+		bgHeight: "auto",
+		bgWidth: "auto",
 		text: "Click to select object",
+		selectedText: "",
 	},
 	trends: [],
 

--- a/src/lib/interactive/components/HoverTextNearMouse.js
+++ b/src/lib/interactive/components/HoverTextNearMouse.js
@@ -111,10 +111,15 @@ class HoverTextNearMouse extends Component {
 		}
 	}
 	render() {
-		return <GenericChartComponent
-			svgDraw={this.renderSVG}
-			drawOn={["mousemove"]}
-		/>;
+		const {text} = this.props;
+		if (text) {
+			return <GenericChartComponent
+				svgDraw={this.renderSVG}
+				drawOn={["mousemove"]}
+			/>;
+		} else {
+			return null;
+		}
 	}
 }
 

--- a/src/lib/interactive/components/InteractiveText.js
+++ b/src/lib/interactive/components/InteractiveText.js
@@ -51,6 +51,8 @@ class InteractiveText extends Component {
 		const {
 			bgFill,
 			bgOpacity,
+			bgStrokeWidth,
+			bgStroke,
 			textFill,
 			fontFamily,
 			fontSize,
@@ -76,7 +78,8 @@ class InteractiveText extends Component {
 		ctx.fillRect(rect.x, rect.y, rect.width, rect.height);
 
 		if (selected) {
-			ctx.strokeStyle = textFill;
+			ctx.strokeStyle = bgStroke;
+			ctx.lineWidth = bgStrokeWidth;
 			ctx.strokeRect(rect.x, rect.y, rect.width, rect.height);
 		}
 
@@ -141,6 +144,8 @@ function helper(props, moreProps, textWidth) {
 InteractiveText.propTypes = {
 	bgFill: PropTypes.string.isRequired,
 	bgOpacity: PropTypes.number.isRequired,
+	bgStrokeWidth: PropTypes.number.isRequired,
+	bgStroke: PropTypes.string.isRequired,
 
 	textFill: PropTypes.string.isRequired,
 	fontFamily: PropTypes.string.isRequired,
@@ -174,7 +179,6 @@ InteractiveText.defaultProps = {
 	type: "SD", // standard dev
 	fontWeight: "normal", // standard dev
 
-	strokeWidth: 1,
 	tolerance: 4,
 	selected: false,
 };

--- a/src/lib/interactive/components/LinearRegressionChannelWithArea.js
+++ b/src/lib/interactive/components/LinearRegressionChannelWithArea.js
@@ -23,11 +23,12 @@ class LinearRegressionChannelWithArea extends Component {
 		if (isDefined(onHover)) {
 			const { mouseXY } = moreProps;
 
-			const { x1, y1, x2, y2 } = helper(this.props, moreProps);
+			const { x1, y1, x2, y2, dy } = helper(this.props, moreProps);
+			const yDiffs = [-dy, 0, dy];
 
-			const hovering = isHovering2(
-				[x1, y1], [x2, y2], mouseXY, tolerance
-			);
+			const hovering = yDiffs.reduce((result, diff) => result || isHovering2(
+				[x1, y1 + diff], [x2, y2 + diff], mouseXY, tolerance
+			), false);
 			return hovering;
 		}
 		return false;

--- a/src/lib/interactive/wrapper/EachFibRetracement.js
+++ b/src/lib/interactive/wrapper/EachFibRetracement.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 
 import { head, last, noop } from "../../utils";
@@ -150,118 +150,128 @@ class EachFibRetracement extends Component {
 		const { hover } = this.state;
 		const { onDragComplete } = this.props;
 		const lines = helper({ x1, x2, y1, y2 });
-		const { enable: hoverTextEnabled, ...restHoverTextProps } = hoverText;
+
+		const { 
+			enable: hoverTextEnabled, 
+			selectedText: hoverTextSelected,
+			text: hoverTextUnselected,
+			...restHoverTextProps 
+		} = hoverText;			
 
 		const lineType = type === "EXTEND" ? "XLINE" : type === "BOUND" ? "LINE" : type;
 		const dir = head(lines).y1 > last(lines).y1 ? 3 : -1.3;
 
 		return <g>
-			{lines.map((line, j) => {
-				const text = `${yDisplayFormat(line.y)} (${line.percent.toFixed(2)}%)`;
+			<Fragment>
+				{lines.map((line, j) => {
+					const text = `${yDisplayFormat(line.y)} (${line.percent.toFixed(2)}%)`;
 
-				const xyProvider = ({ xScale, chartConfig }) => {
-					const { yScale } = chartConfig;
-					const { x1, y1, x2 } = generateLine({
-						type: lineType,
-						start: [line.x1, line.y],
-						end: [line.x2, line.y],
-						xScale,
-						yScale,
-					});
+					const xyProvider = ({ xScale, chartConfig }) => {
+						const { yScale } = chartConfig;
+						const { x1, y1, x2 } = generateLine({
+							type: lineType,
+							start: [line.x1, line.y],
+							end: [line.x2, line.y],
+							xScale,
+							yScale,
+						});
 
-					const x = xScale(Math.min(x1, x2)) + 10;
-					const y = yScale(y1) + dir * 4;
-					return [x, y];
-				};
+						const x = xScale(Math.min(x1, x2)) + 10;
+						const y = yScale(y1) + dir * 4;
+						return [x, y];
+					};
 
-				const firstOrLast = (j === 0) || (j === lines.length - 1);
+					const firstOrLast = (j === 0) || (j === lines.length - 1);
 
-				const interactiveCursorClass = firstOrLast
-					? "react-stockcharts-ns-resize-cursor"
-					: "react-stockcharts-move-cursor";
+					const interactiveCursorClass = firstOrLast
+						? "react-stockcharts-ns-resize-cursor"
+						: "react-stockcharts-move-cursor";
 
-				const interactiveEdgeCursorClass = firstOrLast
-					? "react-stockcharts-ns-resize-cursor"
-					: "react-stockcharts-ew-resize-cursor";
+					const interactiveEdgeCursorClass = firstOrLast
+						? "react-stockcharts-ns-resize-cursor"
+						: "react-stockcharts-ew-resize-cursor";
 
-				const dragHandler = j === 0
-					? this.handleLineNSResizeTop
-					: j === lines.length - 1
-						? this.handleLineNSResizeBottom
-						: this.handleLineMove;
+					const dragHandler = j === 0
+						? this.handleLineNSResizeTop
+						: j === lines.length - 1
+							? this.handleLineNSResizeBottom
+							: this.handleLineMove;
 
-				const edge1DragHandler = j === 0
-					? this.handleLineNSResizeTop
-					: j === lines.length - 1
-						? this.handleLineNSResizeBottom
-						: this.handleEdge1Drag;
-				const edge2DragHandler = j === 0
-					? this.handleLineNSResizeTop
-					: j === lines.length - 1
-						? this.handleLineNSResizeBottom
-						: this.handleEdge2Drag;
+					const edge1DragHandler = j === 0
+						? this.handleLineNSResizeTop
+						: j === lines.length - 1
+							? this.handleLineNSResizeBottom
+							: this.handleEdge1Drag;
+					const edge2DragHandler = j === 0
+						? this.handleLineNSResizeTop
+						: j === lines.length - 1
+							? this.handleLineNSResizeBottom
+							: this.handleEdge2Drag;
 
-				const hoverHandler = interactive
-					? { onHover: this.handleHover, onUnHover: this.handleHover }
-					: {};
-				return <g key={j}>
-					<StraightLine
-						ref={this.saveNodeType(`line_${j}`)}
-						selected={selected || hover}
+					const hoverHandler = interactive
+						? { onHover: this.handleHover, onUnHover: this.handleHover }
+						: {};
+					return <g key={j}>
+						<StraightLine
+							ref={this.saveNodeType(`line_${j}`)}
+							selected={selected || hover}
 
-						{...hoverHandler}
+							{...hoverHandler}
 
-						type={lineType}
-						x1Value={line.x1}
-						y1Value={line.y}
-						x2Value={line.x2}
-						y2Value={line.y}
-						stroke={stroke}
-						strokeWidth={(hover || selected) ? strokeWidth + 1 : strokeWidth}
-						strokeOpacity={strokeOpacity}
-						interactiveCursorClass={interactiveCursorClass}
+							type={lineType}
+							x1Value={line.x1}
+							y1Value={line.y}
+							x2Value={line.x2}
+							y2Value={line.y}
+							stroke={stroke}
+							strokeWidth={(hover || selected) ? strokeWidth + 1 : strokeWidth}
+							strokeOpacity={strokeOpacity}
+							interactiveCursorClass={interactiveCursorClass}
 
-						onDragStart={this.handleLineDragStart}
-						onDrag={dragHandler}
-						onDragComplete={onDragComplete}
-					/>
-					<Text
-						selected={selected}
-						/* eslint-disable */
-						xyProvider={xyProvider} 
-						/* eslint-enable */
-						fontFamily={fontFamily}
-						fontSize={fontSize}
-						fill={fontFill}>{text}</Text>
-					<ClickableCircle
-						ref={this.saveNodeType("edge1")}
-						show={selected || hover}
-						cx={line.x1}
-						cy={line.y}
-						r={r}
-						fill={firstOrLast ? nsEdgeFill : edgeFill}
-						stroke={edgeStroke}
-						strokeWidth={edgeStrokeWidth}
-						interactiveCursorClass={interactiveEdgeCursorClass}
-						onDrag={edge1DragHandler}
-						onDragComplete={onDragComplete} />
-					<ClickableCircle
-						ref={this.saveNodeType("edge2")}
-						show={selected || hover}
-						cx={line.x2}
-						cy={line.y}
-						r={r}
-						fill={firstOrLast ? nsEdgeFill : edgeFill}
-						stroke={edgeStroke}
-						strokeWidth={edgeStrokeWidth}
-						interactiveCursorClass={interactiveEdgeCursorClass}
-						onDrag={edge2DragHandler}
-						onDragComplete={onDragComplete} />
-					<HoverTextNearMouse
-						show={hoverTextEnabled && hover && !selected}
-						{...restHoverTextProps} />
-				</g>;
-			})}
+							onDragStart={this.handleLineDragStart}
+							onDrag={dragHandler}
+							onDragComplete={onDragComplete}
+						/>
+						<Text
+							selected={selected}
+							/* eslint-disable */
+							xyProvider={xyProvider} 
+							/* eslint-enable */
+							fontFamily={fontFamily}
+							fontSize={fontSize}
+							fill={fontFill}>{text}</Text>
+						<ClickableCircle
+							ref={this.saveNodeType("edge1")}
+							show={selected || hover}
+							cx={line.x1}
+							cy={line.y}
+							r={r}
+							fill={firstOrLast ? nsEdgeFill : edgeFill}
+							stroke={edgeStroke}
+							strokeWidth={edgeStrokeWidth}
+							interactiveCursorClass={interactiveEdgeCursorClass}
+							onDrag={edge1DragHandler}
+							onDragComplete={onDragComplete} />
+						<ClickableCircle
+							ref={this.saveNodeType("edge2")}
+							show={selected || hover}
+							cx={line.x2}
+							cy={line.y}
+							r={r}
+							fill={firstOrLast ? nsEdgeFill : edgeFill}
+							stroke={edgeStroke}
+							strokeWidth={edgeStrokeWidth}
+							interactiveCursorClass={interactiveEdgeCursorClass}
+							onDrag={edge2DragHandler}
+							onDragComplete={onDragComplete} />
+					</g>;
+				})}
+			</Fragment>
+			<HoverTextNearMouse
+				show={hoverTextEnabled && hover}
+				{...restHoverTextProps}
+				text={selected ? hoverTextSelected : hoverTextUnselected}
+			/>			
 		</g>;
 	}
 }

--- a/src/lib/interactive/wrapper/EachLinearRegressionChannel.js
+++ b/src/lib/interactive/wrapper/EachLinearRegressionChannel.js
@@ -91,9 +91,14 @@ class EachLinearRegressionChannel extends Component {
 		const hoverHandler = interactive
 			? { onHover: this.handleHover, onUnHover: this.handleHover }
 			: {};
-		const { enable: hoverTextEnabled, ...restHoverTextProps } = hoverText;
 
-		// console.log("SELECTED ->", selected);
+		const { 
+			enable: hoverTextEnabled, 
+			selectedText: hoverTextSelected,
+			text: hoverTextUnselected,
+			...restHoverTextProps 
+		} = hoverText;			
+
 		return <g>
 			<LinearRegressionChannelWithArea
 				ref={this.saveNodeType("area")}
@@ -130,8 +135,10 @@ class EachLinearRegressionChannel extends Component {
 				onDrag={this.handleEdge2Drag}
 				onDragComplete={onDragComplete} />
 			<HoverTextNearMouse
-				show={hoverTextEnabled && hover && !selected}
-				{...restHoverTextProps} />
+				show={hoverTextEnabled && hover}
+				{...restHoverTextProps}
+				text={selected ? hoverTextSelected : hoverTextUnselected}
+			/>
 		</g>;
 	}
 }

--- a/src/lib/interactive/wrapper/EachText.js
+++ b/src/lib/interactive/wrapper/EachText.js
@@ -125,7 +125,7 @@ class EachText extends Component {
 				text={text}
 			/>
 			<HoverTextNearMouse
-				show={hoverTextEnabled && hover && (!selected || Boolean(hoverTextSelected))}
+				show={hoverTextEnabled && hover}
 				{...restHoverTextProps}
 				text={selected ? hoverTextSelected : hoverTextUnselected}
 			/>

--- a/src/lib/interactive/wrapper/EachText.js
+++ b/src/lib/interactive/wrapper/EachText.js
@@ -76,6 +76,8 @@ class EachText extends Component {
 			position,
 			bgFill,
 			bgOpacity,
+			bgStroke,
+			bgStrokeWidth,
 			textFill,
 			fontFamily,
 			fontSize,
@@ -93,7 +95,12 @@ class EachText extends Component {
 			onUnHover: this.handleHover
 		};
 
-		const { enable: hoverTextEnabled, ...restHoverTextProps } = hoverText;
+		const { 
+			enable: hoverTextEnabled, 
+			selectedText: hoverTextSelected,
+			text: hoverTextUnselected,
+			...restHoverTextProps 
+		} = hoverText;
 
 		return <g>
 			<InteractiveText
@@ -105,10 +112,11 @@ class EachText extends Component {
 				onDragStart={this.handleDragStart}
 				onDrag={this.handleDrag}
 				onDragComplete={onDragComplete}
-
 				position={position}
 				bgFill={bgFill}
 				bgOpacity={bgOpacity}
+				bgStroke={bgStroke || textFill}
+				bgStrokeWidth={bgStrokeWidth}
 				textFill={textFill}
 				fontFamily={fontFamily}
 				fontStyle={fontStyle}
@@ -117,8 +125,10 @@ class EachText extends Component {
 				text={text}
 			/>
 			<HoverTextNearMouse
-				show={hoverTextEnabled && hover && !selected}
-				{...restHoverTextProps} />
+				show={hoverTextEnabled && hover && (!selected || Boolean(hoverTextSelected))}
+				{...restHoverTextProps}
+				text={selected ? hoverTextSelected : hoverTextUnselected}
+			/>
 		</g>;
 	}
 }
@@ -139,6 +149,8 @@ EachText.propTypes = {
 	position: PropTypes.array.isRequired,
 	bgFill: PropTypes.string.isRequired,
 	bgOpacity: PropTypes.number.isRequired,
+	bgStrokeWidth: PropTypes.number.isRequired,
+	bgStroke: PropTypes.string,	
 	textFill: PropTypes.string.isRequired,
 
 	fontWeight: PropTypes.string.isRequired,
@@ -158,19 +170,15 @@ EachText.propTypes = {
 EachText.defaultProps = {
 	onDrag: noop,
 	onDragComplete: noop,
-	edgeStroke: "#000000",
-	edgeFill: "#FFFFFF",
-	edgeStrokeWidth: 2,
-	r: 5,
-	strokeWidth: 1,
-	opacity: 1,
+	bgOpacity: 1,
+	bgStrokeWidth: 1,
 	selected: false,
 	fill: "#8AAFE2",
 	hoverText: {
 		...HoverTextNearMouse.defaultProps,
 		enable: true,
-		bgHeight: 18,
-		bgWidth: 120,
+		bgHeight: 'auto',
+		bgWidth: 'auto',
 		text: "Click to select object",
 	}
 };

--- a/src/lib/interactive/wrapper/EachTrendLine.js
+++ b/src/lib/interactive/wrapper/EachTrendLine.js
@@ -151,10 +151,15 @@ class EachTrendLine extends Component {
 
 			onDragComplete,
 		} = this.props;
-		const { hover, anchor } = this.state;
 
-		// console.log("SELECTED ->", selected);
-		const { enable: hoverTextEnabled, ...restHoverTextProps } = hoverText;
+		const { 
+			enable: hoverTextEnabled, 
+			selectedText: hoverTextSelected,
+			text: hoverTextUnselected,
+			...restHoverTextProps 
+		} = hoverText;
+
+		const { hover, anchor } = this.state;
 
 		return <g>
 			<StraightLine
@@ -204,8 +209,10 @@ class EachTrendLine extends Component {
 				onDrag={this.handleEdge2Drag}
 				onDragComplete={this.handleDragComplete} />
 			<HoverTextNearMouse
-				show={hoverTextEnabled && hover && !selected}
-				{...restHoverTextProps} />
+				show={hoverTextEnabled && hover && (!selected || Boolean(hoverTextSelected))}
+				{...restHoverTextProps} 
+				text={selected ? hoverTextSelected : hoverTextUnselected}
+			/>
 		</g>;
 	}
 }

--- a/src/lib/interactive/wrapper/EachTrendLine.js
+++ b/src/lib/interactive/wrapper/EachTrendLine.js
@@ -209,7 +209,7 @@ class EachTrendLine extends Component {
 				onDrag={this.handleEdge2Drag}
 				onDragComplete={this.handleDragComplete} />
 			<HoverTextNearMouse
-				show={hoverTextEnabled && hover && (!selected || Boolean(hoverTextSelected))}
+				show={hoverTextEnabled && hover}
 				{...restHoverTextProps} 
 				text={selected ? hoverTextSelected : hoverTextUnselected}
 			/>


### PR DESCRIPTION
InteractiveText -
  1. fixed bug: hoverText should be set for EachText component.
  2. support 'selectedText' property for hover on selected text item (text for selected item may be different).
  3. support 'hoverText' property for each item (in textList prop). 
  4. hoverText - support 'auto' for bgWidth/bgHeight property (it is
  measured by text width). Set 'auto' as default value for
  bgWidth/bgHeight.
  5. add bgStrokeWidth and bgStroke properties to InteractiveText (for selected text border styling). If bgStroke is not set, textFill color will be used.

TrendLine -
  1. hoverText - support 'auto' for bgWidth/bgHeight property 
  2. support 'selectedText' property for hover on selected text item.

StandardDeviationChannel - 
  1. use default values for hoverText and appearance.
  2. support 'selectedText' property for hover on selected text item (text for selected item may be different).
  3. support 'hoverText' property for each item (in textList prop).
  4. hoverText - support 'auto' for bgWidth/bgHeight property (it is measured by text width). Set 'auto' as default value for bgWidth/bgHeight.
  5. remove redundant 'isRequred' from prop types with default prop values
  6. LinearRegressionChannelWithArea - make component hovered on hover for each its line (this is more user-friendly)

FibonacciRetracement + EachLinearRegressionChannel -
  1. remove duplicated HoverTextNearMouse components for proper display hint opacity
  2. support 'selectedText' property in FibonacciRetracement for hover on selected text item (text for selected item may be different).

HoverTextNearMouse - don't render anything for empty text

other: remove redundant condition for show HoverTextNearMouse (it just will not be shown for empty text/selectedText)