### PR TITLE
fixes in SaveChartAsImage.js

### DIFF
--- a/docs/documentation.js
+++ b/docs/documentation.js
@@ -1,5 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import "@babel/polyfill";
+import "blueimp-canvas-to-blob";
 
 import { csvParse, tsvParse } from  "d3-dsv";
 import { merge } from "d3-array";

--- a/docs/index.js
+++ b/docs/index.js
@@ -1,5 +1,7 @@
 import { tsvParse } from  "d3-dsv";
 import { timeParse } from "d3-time-format";
+import "@babel/polyfill";
+import "blueimp-canvas-to-blob";
 
 import React from "react";
 import ReactDOM from "react-dom";

--- a/docs/lib/page/DarkThemePage.js
+++ b/docs/lib/page/DarkThemePage.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import ReactDOM from "react-dom";
+import canvg from "canvg";
 import { TypeChooser, SaveChartAsImage } from "react-stockcharts/lib/helper";
 
 import ContentSection from "lib/content-section";
@@ -21,7 +22,10 @@ class DarkThemePage extends React.Component {
 	}
 	saveChartAsImage() {
 		const container = ReactDOM.findDOMNode(this.chart); // eslint-disable-line react/no-find-dom-node
-		SaveChartAsImage.saveChartAsImage(container);
+		SaveChartAsImage.saveChartAsImageWithOptions(container, { 
+			canvg,
+			background: "#303030"
+		});
 	}
 	render() {
 		return (

--- a/docs/lib/page/StochasticIndicatorPage.js
+++ b/docs/lib/page/StochasticIndicatorPage.js
@@ -2,6 +2,7 @@
 
 import React from "react";
 import ReactDOM from "react-dom";
+import canvg from "canvg";
 import { TypeChooser, SaveChartAsImage } from "react-stockcharts/lib/helper";
 
 import ContentSection from "lib/content-section";
@@ -21,7 +22,10 @@ class StochasticIndicatorPage extends React.Component {
 	}
 	saveChartAsImage() {
 		const container = ReactDOM.findDOMNode(this.chart); // eslint-disable-line react/no-find-dom-node
-		SaveChartAsImage.saveChartAsImage(container);
+		SaveChartAsImage.saveChartAsImageWithOptions(container, { 
+			canvg,
+			background: "white"
+		});
 	}
 	render() {
 		return (

--- a/docs/lib/page/TrendLineInteractiveIndicatorPage.js
+++ b/docs/lib/page/TrendLineInteractiveIndicatorPage.js
@@ -1,8 +1,7 @@
-
-
 import React from "react";
 import ReactDOM from "react-dom";
 import { TypeChooser, SaveChartAsImage } from "react-stockcharts/lib/helper";
+import canvg from "canvg";
 
 import ContentSection from "lib/content-section";
 import Row from "lib/row";
@@ -21,7 +20,10 @@ class TrendLineInteractiveIndicatorPage extends React.Component {
 	}
 	saveChartAsImage() {
 		const container = ReactDOM.findDOMNode(this.chart); // eslint-disable-line react/no-find-dom-node
-		SaveChartAsImage.saveChartAsImage(container);
+		SaveChartAsImage.saveChartAsImageWithOptions(container, { 
+			canvg,
+			background: "white"
+		});
 	}
 	render() {
 		return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,30 @@
         "@babel/types": "7.0.0-beta.32"
       }
     },
+    "@babel/polyfill": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
+      "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
+      "dev": true,
+      "requires": {
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.32",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.32.tgz",
@@ -141,6 +165,12 @@
         }
       }
     },
+    "abab": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
+      "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
+      "dev": true
+    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -176,6 +206,23 @@
           "version": "4.0.13",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+          "dev": true
+        }
+      }
+    },
+    "acorn-globals": {
+      "version": "1.0.9",
+      "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-1.0.9.tgz",
+      "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
+      "dev": true,
+      "requires": {
+        "acorn": "2.7.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
           "dev": true
         }
       }
@@ -319,6 +366,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "dev": true
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
     "array-find-index": {
@@ -1457,6 +1510,12 @@
       "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
       "dev": true
     },
+    "blueimp-canvas-to-blob": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/blueimp-canvas-to-blob/-/blueimp-canvas-to-blob-3.14.0.tgz",
+      "integrity": "sha512-i6I2CiX1VR8YwUNYBo+dM8tg89ns4TTHxSpWjaDeHKcYS3yFalpLCwDaY21/EsJMufLy2tnG4j0JN5L8OVNkKQ==",
+      "dev": true
+    },
     "bn.js": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
@@ -1759,6 +1818,18 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000755.tgz",
       "integrity": "sha1-nOX24GvXXsggmr6IU8O+7wIkjWU=",
       "dev": true
+    },
+    "canvg": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-1.5.3.tgz",
+      "integrity": "sha512-7Gn2IuQzvUQWPIuZuFHrzsTM0gkPz2RRT9OcbdmA03jeKk8kltrD8gqUzNX15ghY/4PV5bbe5lmD6yDLDY6Ybg==",
+      "dev": true,
+      "requires": {
+        "jsdom": "8.5.0",
+        "rgbcolor": "1.0.1",
+        "stackblur-canvas": "1.4.1",
+        "xmldom": "0.1.27"
+      }
     },
     "caseless": {
       "version": "0.11.0",
@@ -2400,6 +2471,21 @@
         "source-map": "0.5.7"
       }
     },
+    "cssom": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
+      "dev": true,
+      "requires": {
+        "cssom": "0.3.4"
+      }
+    },
     "currently-unhandled": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
@@ -3007,6 +3093,34 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
+    },
+    "escodegen": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
+      "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+      "dev": true,
+      "requires": {
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "escope": {
       "version": "3.6.0",
@@ -3643,6 +3757,11 @@
           }
         }
       }
+    },
+    "file-saver": {
+      "version": "1.3.8",
+      "resolved": "http://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz",
+      "integrity": "sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -5451,6 +5570,39 @@
       "dev": true,
       "optional": true
     },
+    "jsdom": {
+      "version": "8.5.0",
+      "resolved": "http://registry.npmjs.org/jsdom/-/jsdom-8.5.0.tgz",
+      "integrity": "sha1-1Nj12/J2hjW2KmKCO5R89wcevJg=",
+      "dev": true,
+      "requires": {
+        "abab": "1.0.4",
+        "acorn": "2.7.0",
+        "acorn-globals": "1.0.9",
+        "array-equal": "1.0.0",
+        "cssom": "0.3.4",
+        "cssstyle": "0.2.37",
+        "escodegen": "1.11.0",
+        "iconv-lite": "0.4.18",
+        "nwmatcher": "1.4.4",
+        "parse5": "1.5.1",
+        "request": "2.79.0",
+        "sax": "1.2.4",
+        "symbol-tree": "3.2.2",
+        "tough-cookie": "2.3.4",
+        "webidl-conversions": "3.0.1",
+        "whatwg-url": "2.0.1",
+        "xml-name-validator": "2.0.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "2.7.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-2.7.0.tgz",
+          "integrity": "sha1-q259nYhqrKiwhbwzEreaGYQz8Oc=",
+          "dev": true
+        }
+      }
+    },
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
@@ -6327,6 +6479,12 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
       "dev": true
     },
+    "nwmatcher": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.4.tgz",
+      "integrity": "sha512-3iuY4N5dhgMpCUrOVnuAdGrgxVqV2cJpM+XNccjR2DKOB1RUP0aA+wGXEiNziG/UKboFyGBIoKOaNlJxx8bciQ==",
+      "dev": true
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
@@ -6571,6 +6729,12 @@
       "requires": {
         "error-ex": "1.3.1"
       }
+    },
+    "parse5": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "integrity": "sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=",
+      "dev": true
     },
     "parseurl": {
       "version": "1.3.2",
@@ -7962,6 +8126,12 @@
         "signal-exit": "3.0.2"
       }
     },
+    "rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha1-1lBezbMEplldom+ktDMHMGd1lF0=",
+      "dev": true
+    },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
@@ -8518,6 +8688,12 @@
         }
       }
     },
+    "stackblur-canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-1.4.1.tgz",
+      "integrity": "sha1-hJqm+UsnL/JvZHH6QTDtH35HlVs=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
@@ -8687,6 +8863,12 @@
         "whet.extend": "0.9.9"
       }
     },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "dev": true
+    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -8830,6 +9012,12 @@
       "requires": {
         "punycode": "1.4.1"
       }
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
@@ -9247,6 +9435,12 @@
         "minimalistic-assert": "1.0.0"
       }
     },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "dev": true
+    },
     "webpack": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.8.1.tgz",
@@ -9658,6 +9852,16 @@
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
       "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
     },
+    "whatwg-url": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-2.0.1.tgz",
+      "integrity": "sha1-U5ayBD8CDub3BNnEXqhRnnJN5lk=",
+      "dev": true,
+      "requires": {
+        "tr46": "0.0.3",
+        "webidl-conversions": "3.0.1"
+      }
+    },
     "whet.extend": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz",
@@ -9751,6 +9955,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/xml-char-classes/-/xml-char-classes-1.0.0.tgz",
       "integrity": "sha1-ZGV4SKIP/F31g6Qq2KJ3tFErvE0=",
+      "dev": true
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "integrity": "sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=",
+      "dev": true
+    },
+    "xmldom": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
+      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk=",
       "dev": true
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "d3-time": "^1.0.8",
     "d3-time-format": "^2.1.1",
     "debug": "^3.1.0",
+    "file-saver": "^1.3.8",
     "lodash.flattendeep": "^4.4.0",
     "prop-types": "^15.6.0",
     "save-svg-as-png": "^1.4.5"
@@ -55,6 +56,7 @@
     "react-dom": "^15.0.0 || ^16.0.0"
   },
   "devDependencies": {
+    "@babel/polyfill": "^7.0.0",
     "autoprefixer-loader": "^3.2.0",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
@@ -63,7 +65,9 @@
     "babel-preset-env": "^1.6.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-3": "^6.24.1",
+    "blueimp-canvas-to-blob": "^3.14.0",
     "bootstrap": "^3.3.7",
+    "canvg": "^1.5.3",
     "cross-env": "^5.1.1",
     "css-loader": "^0.28.7",
     "d3-dsv": "^1.0.8",

--- a/src/lib/helper/SaveChartAsImage.js
+++ b/src/lib/helper/SaveChartAsImage.js
@@ -1,69 +1,187 @@
-
-
 import saveAsPng from "save-svg-as-png";
-import { isDefined } from "../utils";
+import FileSaver from "file-saver";
 
-const dx = 0;
-const dy = 0;
+// ==== save-svg-as-png hack ====
+// we want width/height from svg, because Image.width/height returns 0 in IE11.
+// saveAsPng.svgAsDataUri does not give us width/height in done parameter.
+// therefore, we use saveAsPng.prepareSvg and copy some code from saveAsPng
+// (svg encode).
+// We will remove this code and use saveAsPng.svgAsDataUri when this PR will
+// be accepted: https://github.com/exupero/saveSvgAsPng/pull/193
+const svgDocType = '<?xml version="1.0" standalone="no"?>' +
+  '<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" ' +
+    '"http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd" [<!ENTITY nbsp "&#160;">]>';
+
+function reEncode(data) {
+	data = encodeURIComponent(data);
+	data = data.replace(/%([0-9A-F]{2})/g, function(match, p1) {
+		const c = String.fromCharCode("0x" + p1);
+		return c === "%" ? "%25" : c;
+	});
+	return decodeURIComponent(data);
+}
+// ==== save-svg-as-png hack end ====
 
 const SaveChartAsImage = {
-	save(doc, container, background, cb) {
-		saveAsPng.svgAsDataUri(container.getElementsByTagName("svg")[0], {}, function(uri) {
-			// eslint-disable-next-line prefer-const
-			let image = new Image();
+	save(doc, container, { background, cb, paddings, canvg }) {
+		const {
+			left: paddingLeft = 0,
+			top: paddingTop = 0,
+			right: paddingRight = 0,
+			bottom: paddingBottom = 0,
+		} = paddings || {};
+
+		const svgElement = container.getElementsByTagName("svg")[0];
+		// see comment on save-svg-as-png hack.
+		// we need width/height of svg here, because Image.width/height returns 0 in IE11
+		// maybe, this bug exits only when we set image.src to svg as dataurl...
+		// anyway, this bug exists, and we need some workaround for it.
+		saveAsPng.prepareSvg(svgElement, {}, function(svgDataUri, width, height) {
+			const image = new Image();
+			// eslint-disable-next-line const-immutable/no-mutation
 			image.onload = function() {
+				const makeCanvas = () => {
+					const canvas = doc.createElement("canvas");
+					const context = canvas.getContext("2d");
 
-				// eslint-disable-next-line prefer-const
-				let canvas = doc.createElement("canvas");
-				canvas.width = image.width;
-				canvas.height = image.height;
+					// we should correctly scale canvas (for devices with Retina-like screen)
+					const devicePixelRatio = window.devicePixelRatio || 1;
+					const backingStoreRatio =
+						context.webkitBackingStorePixelRatio ||
+						context.mozBackingStorePixelRatio ||
+						context.msBackingStorePixelRatio ||
+						context.oBackingStorePixelRatio ||
+						context.backingStorePixelRatio ||
+						1;
 
-				// eslint-disable-next-line prefer-const
-				let context = canvas.getContext("2d");
+					const pixelRatio = devicePixelRatio / backingStoreRatio;
 
-				if (isDefined(background)) {
-					context.fillStyle = background;
-					context.fillRect(0, 0, canvas.width, canvas.height);
-				}
-				const canvasList = container.getElementsByTagName("canvas");
-				for (let i = 0; i < canvasList.length; i++) {
-					const each = canvasList[i];
-					if (isDefined(each)) {
-						const parent = each.parentNode.parentNode.getBoundingClientRect();
-						const rect = each.getBoundingClientRect();
-						context.drawImage(each, rect.left - parent.left + dx, rect.top - parent.top + dy);
+					const canvasWidth = (width + paddingLeft + paddingRight) * pixelRatio;
+					const canvasHeight = (height + paddingTop + paddingBottom) * pixelRatio;
+
+					// eslint-disable-next-line const-immutable/no-mutation
+					canvas.width = canvasWidth;
+					// eslint-disable-next-line const-immutable/no-mutation
+					canvas.height = canvasHeight;
+					if (pixelRatio !== 1) {
+						// don't scale context, because source canvases are scaled by ChartCanvas code
+					}
+
+					if (background != null) {
+						// eslint-disable-next-line const-immutable/no-mutation
+						context.fillStyle = background;
+						context.fillRect(0, 0, canvasWidth, canvasHeight);
+					}
+					const canvasList = container.getElementsByTagName("canvas");
+					for (let i = 0; i < canvasList.length; i++) {
+						const each = canvasList[i];
+						if (each) {
+							const parent = each.parentNode.parentNode.getBoundingClientRect();
+							const rect = each.getBoundingClientRect();
+							context.drawImage(
+								each,
+								(rect.left - parent.left + paddingLeft) * pixelRatio,
+								(rect.top - parent.top + paddingTop) * pixelRatio
+							);
+						}
+					}
+
+					const imageWidth = image.width;
+					const imageHeight = image.height;
+					return [canvas, context, pixelRatio, imageWidth, imageHeight];
+				};
+
+				try {
+					const [
+						canvas,
+						context,
+						pixelRatio,
+						imageWidth,
+						imageHeight,
+					] = makeCanvas();
+
+					// draw svg image (svg layer ChartCanvas) to canvas with all canvas layers painted.
+					// in ie11, after painting any image (even with src as svg/dataUrl) to canvas, canvas
+					// will became locked to save, and canvas.toBlob will cause error
+					context.drawImage(
+						image,
+						paddingLeft * pixelRatio,
+						paddingTop * pixelRatio,
+						imageWidth * pixelRatio,
+						imageHeight * pixelRatio
+					);
+
+					// check for security error bug in ie11. it will throw an error
+					// synchronously, and ie11 fallback will be used (in catch block)
+					canvas.toDataURL();
+
+					// in ie11, security bug will happen here (asynchronously).
+					// so, we can't handle it here, we handle it in code above (canvas.toDataURL)
+					canvas.toBlob(cb);
+				} catch (e) {
+					if (canvg) {
+						const [
+							canvas,
+							context,
+							pixelRatio,
+							imageWidth,
+							imageHeight,
+						] = makeCanvas();
+
+						// use canvg as fallback for ie11, to draw svg layer using canvas api
+						// ie11 locks canvas after drawing any image, and it became impossible to save
+						const canvasSvg = doc.createElement("canvas");
+						canvg(canvasSvg, svgDataUri, {
+							scaleWidth: imageWidth * pixelRatio,
+							scaleHeight: imageHeight * pixelRatio,
+						});
+
+						// draw canvas with svg-layer to canvas. it is safe for ie11 (and other buggy browsers)
+						context.drawImage(
+							canvasSvg,
+							paddingLeft * pixelRatio,
+							paddingTop * pixelRatio
+						);
+
+						canvas.toBlob(cb);
+					} else {
+						throw new Error("Send canvg parameter (https://github.com/canvg/canvg) to handle ie11 security bug on canvas saving");
 					}
 				}
-
-				context.drawImage(image, dx, dy);
-				cb(canvas.toDataURL("image/png"));
 			};
+
+			const uri = "data:image/svg+xml;base64," + window.btoa(reEncode(svgDocType + svgDataUri));
+			// eslint-disable-next-line const-immutable/no-mutation
 			image.src = uri;
 		});
 	},
-	saveWithWhiteBG(doc, container, cb) {
-		return this.saveWithBG(doc, container, "white", cb);
-	},
-	saveWithDarkBG(doc, container, cb) {
-		return this.saveWithBG(doc, container, "#303030", cb);
-	},
-	saveWithBG(doc, container, background, cb) {
-		return this.save(doc, container, background, cb);
-	},
-	saveChartAsImage(container) {
-		this.saveWithWhiteBG(document, container, function(src) {
-			const a = document.createElement("a");
-			a.setAttribute("href", src);
-			a.setAttribute("download", "Chart.png");
 
-			document.body.appendChild(a);
-			a.addEventListener("click", function(/* e */) {
-				a.parentNode.removeChild(a);
-			});
-
-			a.click();
+	saveWithWhiteBG(container, paddings, cb) {
+		return this.saveWithBG(container, "white", paddings, cb);
+	},
+	saveWithDarkBG(container, paddings, cb) {
+		return this.saveWithBG(container, "#303030", paddings, cb);
+	},
+	saveWithBG(container, background, paddings, cb) {
+		return this.save(document, container, { background, paddings, cb });
+	},
+	saveChartAsImage(container, background, paddings, cb) {
+		return this.saveChartAsImageWithOptions(container, {
+			background, paddings, cb
 		});
-	}
+	},
+	saveChartAsImageWithOptions(container, options) {
+		const cb = blob => {
+			FileSaver.saveAs(blob, options.fileName || "Chart.png");
+			if (options.cb) {
+				options.cb();
+			}
+		};
+		return this.save(document, container, {
+			...options,
+			cb
+		});
+	},
 };
 
 export default SaveChartAsImage;


### PR DESCRIPTION
fixes in SaveChartAsImage.js
1. use devicePixelRatio / backingStorePixelRatio for correct image scaling on Retina devices

2. use file-saver for correct image saving on IE/Edge/Safari

3. add canvg parameter for fallback when saving in IE11/Edge (IE has security bug when trying to save canvas with any svg image painted on). 
See https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/1015651/ or similar bugreports. 
See description for canvg parameter here: https://github.com/exupero/saveSvgAsPng (canvg - If canvg is passed in, it will be used to write svg to canvas. This will allow support for Internet Explorer)

4. Add paddings parameter to save functions

5. Add save-svg-as-png workaround to fix bug with saving on IE11: we want width/height from svg, because Image.width/height returns 0 in IE11. 
Maybe, this bug exits only when we set image.src to svg as dataurl... 
Anyway, this bug exists, and we need some workaround for it.

7. Use file-saver https://github.com/eligrey/FileSaver.js to have correct cross-platform image saving (solution with <a> tag does not work on IE11/Edge, and Safari).

8. Add polyfills to documentation pages (for IE11 compatibility): @babel/polyfill, blueimp-canvas-to-blob, and canvg. 
Also, use saveChartAsImageWithOptions method to send canvg parameter for IE11/Edge compatibility