### PR TITLE
Add reexport of internal components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,25 +7,17 @@ export { default as GenericChartComponent } from "./lib/GenericChartComponent";
 export { default as GenericComponent } from "./lib/GenericComponent";
 export { default as BackgroundText } from "./lib/BackgroundText";
 export { default as ZoomButtons } from "./lib/ZoomButtons";
+export { getAxisCanvas, getMouseCanvas } from "./lib/GenericComponent";
+export * from "./lib/scale";
+export * from "./lib/series";
+export * from "./lib/axes";
+export * from "./lib/coordinates";
+export * from "./lib/tooltip";
+export * from "./lib/helper";
+export * from "./lib/utils";
+export * from "./lib/indicator";
+export * from "./lib/interactive";
+export * from "./lib/algorithm";
+export * from "./lib/annotation";
 
 export const version = "0.7.8";
-
-/*
-// chart types & Series
-import * as series from "./lib/series";
-import * as scale from "./lib/scale";
-
-import * as coordinates from "./lib/coordinates";
-import * as indicator from "./lib/indicator";
-import * as algorithm from "./lib/algorithm";
-
-import * as annotation from "./lib/annotation";
-
-import * as axes from "./lib/axes";
-import * as tooltip from "./lib/tooltip";
-import * as helper from "./lib/helper";
-
-import * as interactive from "./lib/interactive";
-import * as utils from "./lib/utils";
-
-*/

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ export * from "./lib/helper";
 export * from "./lib/utils";
 export * from "./lib/indicator";
 export * from "./lib/interactive";
-export * from "./lib/algorithm";
+export { default as algorithm } from "./lib/algorithm";
 export * from "./lib/annotation";
 
 export const version = "0.7.8";


### PR DESCRIPTION
Add reexport of internal components (required for correct import from es/index.js module, in webpack4 to make treeshaking work).

Importing something directly from '/lib/axes/' or something else imports specified module from /node_modules/react-stockcharts/lib/* (common js modules build), not from /node_modules/react-stockcharts/es/lib/*.
This disables tree-shaking optimizationsI've add re-exports to root index.js, because for import {LineSeries} from 'react-stockcharts', webpack uses react-stockcharts/es/lib/* files, with es6-style exports/imports, and this makes tree-shaking possible.