### PR TITLE
ScatterSeries - fix for functors in marker rendering  (fixes #784)

### DIFF
--- a/src/lib/series/ScatterSeries.js
+++ b/src/lib/series/ScatterSeries.js
@@ -30,8 +30,8 @@ class ScatterSeries extends Component {
 
 		return <g className={className}>
 			{points.map((point, idx) => {
-				const { marker: Marker } = point;
-				return <Marker key={idx} {...markerProps} point={point} />;
+                const { marker: Marker, stroke, fill, ...restPointData} = point;
+                return <Marker key={idx} {...markerProps} stroke={stroke} fill={fill} point={restPointData} />;
 			})}
 		</g>;
 	}


### PR DESCRIPTION
Fixes #784. Also, canvas rendering is looking forward to be fixed - to support for functors for markers: `stroke(d)` and `fill(d)`