### PR TITLE
Fix Drawingobjectselector Bug On Multiple Chartcanvas

### DIFF
--- a/src/lib/interactive/DrawingObjectSelector.js
+++ b/src/lib/interactive/DrawingObjectSelector.js
@@ -66,6 +66,14 @@ class DrawingObjectSelector extends Component {
 				const morePropsForChart = getMorePropsForChart(
 					moreProps, each.chartId
 				);
+				
+				if (morePropsForChart === false) {
+					return {
+						type: each.type,
+						chartId: each.chartId,
+						objects: []
+					};
+				}
 
 				const objects = each.node.getSelectionState(morePropsForChart);
 

--- a/src/lib/interactive/utils.js
+++ b/src/lib/interactive/utils.js
@@ -69,6 +69,10 @@ export function getMorePropsForChart(moreProps, chartId) {
 	const { chartConfig: chartConfigList } = moreProps;
 	const chartConfig = find(chartConfigList, each => each.id === chartId);
 
+	if (isNotDefined(chartConfig)) {
+		return false;
+	}
+
 	const { origin } = chartConfig;
 	const mouseXY = getMouseXY(moreProps, origin);
 	return {


### PR DESCRIPTION
Hello,

This bug is in case, of multiple chartCanvas, with multiple interactives, when selecting different canvas, it get confused

The problem is that there is no identification between the selected chart props, and interactives loop

If not clear i can provide a context